### PR TITLE
fix: address Copilot review comments from PR #11

### DIFF
--- a/docs/ops-portal/audit.md
+++ b/docs/ops-portal/audit.md
@@ -97,7 +97,7 @@ The platform maintains a separate hash chain for `PLATFORM_OPS_*` events, indepe
 3. Review the results
 
 :::warning Broken Chain
-A broken chain link may indicate unauthorised modification of audit data. Escalate to the security team immediately and do not make further changes to the affected tenant's data until the investigation is complete.
+A broken chain link may indicate unauthorized modification of audit data. Escalate to the security team immediately and do not make further changes to the affected tenant's data until the investigation is complete.
 :::
 
 ## Exporting Audit Data

--- a/docs/ops-portal/dashboard.md
+++ b/docs/ops-portal/dashboard.md
@@ -40,7 +40,7 @@ Click any subsystem row to navigate directly to the relevant portal section.
 The Recent Activity feed lists the last 50 `PLATFORM_OPS_*` audit events across all tenants. Each row shows:
 
 - **Timestamp** — UTC time of the event
-- **Event Type** — Colour-coded `PLATFORM_OPS_` badge
+- **Event Type** — Color-coded `PLATFORM_OPS_` badge
 - **Actor** — Platform admin who performed the action
 - **Target** — Affected tenant, user, or firm
 - **Summary** — Human-readable description

--- a/docs/ops-portal/data-ops.md
+++ b/docs/ops-portal/data-ops.md
@@ -30,12 +30,19 @@ Deletion requests are created in three ways:
 
 ### The 30-Day DPA Grace Period
 
-When a deletion request is raised, the following sequence begins:
+Deletion requests go through two phases: a **pending approval** phase (for requests that require admin approval) and a **30-day grace period** once the request is approved.
 
-1. **Day 0** — Request created; record is soft-deleted and inaccessible to the tenant
+For the purposes of the 30-day window, **Day 0** is defined as:
+
+- The time the request is **approved in the Ops Portal** for user or tenant-owner initiated requests that require approval.
+- The time the request is **created by a platform admin** when it is created and approved in a single step.
+
+From Day 0, the following sequence begins:
+
+1. **Day 0** — Request enters the grace period; the record is soft-deleted and is inaccessible to the tenant
 2. **Days 1–30** — Grace period: data is preserved and can be restored if the request is cancelled
-3. **Day 30** — Hard-delete job runs; personal data is permanently erased and replaced with anonymised placeholders
-4. **After Day 30** — Audit entries referencing the deleted record retain anonymised identifiers to preserve chain integrity
+3. **Day 30** — Hard-delete job runs; personal data is permanently erased and replaced with anonymized placeholders
+4. **After Day 30** — Audit entries referencing the deleted record retain anonymized identifiers to preserve chain integrity
 
 If a legal hold is active at Day 30, the hard-delete job is blocked until the hold is released.
 

--- a/docs/ops-portal/index.md
+++ b/docs/ops-portal/index.md
@@ -44,9 +44,9 @@ These events cannot be edited or deleted and are visible in both the Ops Audit L
 
 ### Health Indicators
 
-Throughout the portal, tenants and users are colour-coded by health status:
+Throughout the portal, tenants and users are color-coded by health status:
 
-| Colour | Meaning |
+| Color | Meaning |
 |--------|---------|
 | 🟢 **Green** | Healthy — no issues detected |
 | 🟡 **Yellow** | Warning — attention recommended |

--- a/docs/ops-portal/users.md
+++ b/docs/ops-portal/users.md
@@ -93,10 +93,10 @@ Soft-deletion removes the user from all tenant memberships and prevents login wh
 3. Enter the reason and legal basis
 4. Click **Confirm**
 
-A `PLATFORM_OPS_USER_SOFT_DELETED` audit event is created. Soft-deleted users can be restored within the 30-day DPA grace period. After 30 days, the record is anonymised unless a legal hold is in place.
+A `PLATFORM_OPS_USER_SOFT_DELETED` audit event is created. Soft-deleted users can be restored within the 30-day DPA grace period. After 30 days, the record is anonymized unless a legal hold is in place.
 
 :::warning Data Protection
-Soft-deletion does not remove personal data immediately. If a deletion is requested under data-protection law, use the [Data Operations](/docs/ops-portal/data-ops) workflow to ensure the correct 30-day grace period and anonymisation steps are followed.
+Soft-deletion does not remove personal data immediately. If a deletion is requested under data-protection law, use the [Data Operations](/docs/ops-portal/data-ops) workflow to ensure the correct 30-day grace period and anonymization steps are followed.
 :::
 
 ## Next Steps


### PR DESCRIPTION
Implements all 7 valid Copilot review comments from PR #11.

## Spelling (British → American English)
- `unauthorised` → `unauthorized` (audit.md)
- `anonymised` → `anonymized` (data-ops.md, users.md)
- `anonymisation` → `anonymization` (users.md)
- `colour-coded`/`Colour` → `color-coded`/`Color` (index.md, dashboard.md)

## Content
- Clarified 30-day DPA grace period: added "pending approval" phase distinction and explicit Day 0 definition for admin vs user-initiated requests

Verified: Docusaurus build succeeds, zero British English remaining in ops-portal docs.