### PR TITLE
fix: address Copilot review comments from PR #16

### DIFF
--- a/docs/data-ops/deletion-requests.md
+++ b/docs/data-ops/deletion-requests.md
@@ -94,7 +94,7 @@ After the 30-day grace period expires, an operator can execute the deletion:
 5. Click **Confirm Execution**
 
 :::danger Irreversible Action
-Data deletion is permanent and cannot be undone. All associated records, attachments, and audit references are destroyed. Ensure you have exported any data required for legal or compliance purposes before executing.
+Data deletion is permanent and cannot be undone. All associated records and attachments are destroyed. Audit trail entries remain immutable, but may display redacted or anonymized field values after deletion. Ensure you have exported any data required for legal or compliance purposes before executing.
 :::
 
 The request status changes to **Completed** and a final audit entry is created.

--- a/docs/data-ops/index.md
+++ b/docs/data-ops/index.md
@@ -26,7 +26,7 @@ Per-business retention policies are enforced automatically. The system defaults 
 [Learn more about retention monitoring](/docs/data-ops/retention-monitoring)
 
 ### Business Data Export
-Operators can export a complete JSON snapshot of all data belonging to a business. This includes transactions, returns, audit logs, and settings.
+Operators can export a complete JSON snapshot of all data belonging to a business. This includes transactions, VAT returns, compliance scores, import batches, and privacy & settings data.
 
 [Learn more about business data export](/docs/data-ops/data-export)
 


### PR DESCRIPTION
Both Copilot comments valid: remove 'audit logs' from export summary (not in actual export), clarify audit entries remain immutable after deletion (consistent with WORM audit trail).