### PR TITLE
Wave 2: VAT Returns state machine + terminology overhaul (closes #141)

### DIFF
--- a/docs/vat-returns/generate-return.mdx
+++ b/docs/vat-returns/generate-return.mdx
@@ -74,13 +74,15 @@ If you find errors in a Draft return:
 2. Delete the draft return
 3. Generate a new return
 
-### After Submission (Amendment)
-If errors are found after filing:
-1. Navigate to the submitted return
-2. Click **Amend**
-3. Make corrections to the affected line items
-4. Submit the amendment
-5. The return status changes to **Amended**
+### After Lodgement (Amendment)
+If errors are found after a return has been lodged:
+1. Navigate to the lodged return on the VAT Returns page.
+2. Click **Amend** — Comply creates a new return in the **Amendment Draft** state. The original lodged return is preserved unchanged for the audit trail.
+3. Make corrections to the affected line items.
+4. Submit the amendment through the same workflow — validation, Section 61 acknowledgement, signatory capture, artifact generation, and Record DIR Acknowledgement.
+5. When the amendment is lodged it follows the same lifecycle and ends at **Lodged** (or **Lodged & Paid** once paid). There is no separate "Amended" terminal state.
+
+See [VAT Returns Overview](/docs/vat-returns/) for the full state machine.
 
 ## By Statute References
 

--- a/docs/vat-returns/index.md
+++ b/docs/vat-returns/index.md
@@ -39,15 +39,25 @@ Each VAT return includes:
 
 ## Return Lifecycle
 
-| Status | Description |
-|--------|-------------|
-| **Draft** | Return generated but not finalized — can be edited |
-| **Ready** | All validations passed, ready for submission |
-| **Filed** | Return marked as filed after you submit via OTAS |
-| **Amended** | A correction has been submitted for a previously filed return |
+Comply tracks every VAT return through a structured eight-state lifecycle. Each transition is recorded in the [audit trail](/docs/audit/) with a named event so the regulatory record is reproducible.
 
-:::note
-The "Filed" status is manually marked by you after submitting via the DIR's Online Tax Administration System (OTAS). CoralLedger Comply does not currently receive direct confirmation from the DIR.
+| State | Displayed label | Description |
+|---|---|---|
+| **Draft** | Draft | Return created from the period's transactions; can still be edited |
+| **Ready to File** | Ready to File | All validations passed and the Section 61 acknowledgement + signatory have been captured. The return is locked from edits |
+| **Filing in Progress** | Filing in Progress | Artifacts (PDF / XML / Excel / Form 301) are being generated. Brief — usually seconds |
+| **Awaiting Lodgement** | Awaiting Lodgement | Artifacts are ready. You now submit externally to the DIR via OTAS / a DIR office / an authorised agent, then return to Comply to record the lodgement |
+| **Lodged** | Lodged | You have recorded the DIR lodgement using **Record DIR Acknowledgement**. The `RETURN_LODGED_WITH_DIR` audit entry has been written. Payable returns wait here until payment is recorded |
+| **Lodged & Paid** | Lodged & Paid | Final state for payable returns once cumulative payments cover the net VAT due. Credit/zero returns reach this state automatically immediately after Lodged |
+| **Amendment Draft** | Amendment Draft | A correction to a previously-lodged return is being composed. When lodged, the amendment goes through the same lifecycle and ends at Lodged / Lodged & Paid — there is no separate "Amended" final state |
+| **Disputed** | Disputed | A previously-lodged return is under DIR dispute. Used when the DIR challenges the return; tracking-only state |
+
+:::note Lodgement, not "filing"
+The regulatorily significant transition is **lodgement** — recorded by you in Comply when you have submitted the return to the DIR. "Filed" is not a state name in Comply; the displayed labels are **Awaiting Lodgement**, **Lodged**, and **Lodged & Paid**. Comply does not currently receive direct confirmation from the DIR.
+:::
+
+:::info Every return passes through Lodged first (VR-STATE-001)
+Even **credit and zero-balance returns** transition through `Lodged` before reaching `Lodged & Paid`, so the `RETURN_LODGED_WITH_DIR` audit entry always has a clean lodgement timestamp. Credit/zero returns auto-advance to `Lodged & Paid` immediately after the audit entry has been written. This is a deliberate regulatory invariant.
 :::
 
 ## DIR Form Fields (L1-L31)

--- a/docs/vat-returns/submit-return.md
+++ b/docs/vat-returns/submit-return.md
@@ -58,20 +58,25 @@ CoralLedger Comply maintains all your return history for the required 7-year ret
 
 ## Filing Status
 
-Track your return through its full lifecycle in CoralLedger Comply:
-- **Draft** — Generated but not finalized
-- **Ready** — All validations passed
-- **Filed** — Marked by you as submitted to DIR via OTAS
-- **Amended** — Correction submitted for a previously filed return
+Comply tracks every return through an eight-state lifecycle. The states most relevant to submission are:
+
+- **Awaiting Lodgement** — artifacts have been generated; you now submit externally to the DIR.
+- **Lodged** — you have recorded the DIR lodgement in Comply via **Record DIR Acknowledgement**.
+- **Lodged & Paid** — final state once payment is recorded (or automatically for credit/zero returns).
+
+See the canonical state machine table on the [VAT Returns Overview](/docs/vat-returns/) page.
 
 ## Amendments
 
-If you need to correct a filed return:
-1. Navigate to the submitted return
-2. Click **Amend**
-3. Make corrections to the affected line items
-4. Submit the amendment
-5. The return status changes to **Amended**
+If you need to correct a previously-lodged return:
+
+1. Navigate to the lodged return on the VAT Returns page.
+2. Click **Amend**. The amendment is created in the **Amendment Draft** state — distinct from the original return, which remains in its existing Lodged / Lodged & Paid state for audit history.
+3. Make corrections to the affected line items.
+4. Submit the amendment through the same approval and submission workflow as a fresh return — Section 61 acknowledgement, signatory capture, artifact generation, and Record DIR Acknowledgement.
+5. When the amendment is lodged it follows the same lifecycle and ends at **Lodged** (or **Lodged & Paid** once paid).
+
+There is no separate "Amended" final state — both the original return and its amendment are durable lifecycle records visible in the audit trail.
 
 ## By Statute References
 


### PR DESCRIPTION
## Summary

Wave 2 of the Phase 1 docs-vs-Comply remediation (epic #140). Foundational rewrite of the VAT Returns state-machine + terminology to match the canonical 8-state `FilingState` lifecycle used by Comply.

This is the load-bearing rewrite — Waves 3–6 build on the new vocabulary.

## What changes

### `docs/vat-returns/index.md` — Return Lifecycle section

The 4-row state table:

| Status | Description |
|---|---|
| **Draft** | Return generated but not finalized |
| **Ready** | All validations passed |
| **Filed** | Return marked as filed after you submit via OTAS |
| **Amended** | A correction has been submitted |

is replaced with the canonical 8-row table mapping each `FilingState` enum value to its **displayed label** (per `ViewFiledReturn.razor:657-665`) and a plain-English description. Adds a `VR-STATE-001` callout explaining the every-return-passes-through-Lodged-first invariant.

### `docs/vat-returns/submit-return.md` — Filing Status + Amendments

Duplicate 4-row table replaced with a link to the canonical lifecycle on the index page. Amendments section corrected — `Amended` is **not** a final state.

### `docs/vat-returns/generate-return.mdx` — After-Submission Amendment

Same `Amended` correction applied here.

## Key regulatory corrections

1. **"Filed" is not a state in Comply.** The user-visible labels are `Awaiting Lodgement` / `Lodged` / `Lodged & Paid`.
2. **The regulatorily significant transition is lodgement**, captured in the Record DIR Acknowledgement dialog — not "filing" as the docs claimed.
3. **`Amended` is not a final state.** Amendments use `AmendmentDraft` as a working state, then end at `Lodged` / `Lodged & Paid` through the same lifecycle. The original lodged return is preserved unchanged for the audit trail.
4. **VR-STATE-001 invariant documented inline:** every return — including credit/zero — transitions through `Lodged` first. Credit/zero auto-advances to `Lodged & Paid` through FW-003 **after** the `RETURN_LODGED_WITH_DIR` audit entry has been written.

## Verification

- Docusaurus build: ✅ green
- Resurrection guards (sitewide grep, all return 0 hits):
  - `**Filed**` (as state-name)
  - `**Amended**` (as state-name)
  - `**Ready**` (as state-name, distinct from "Ready to File")
  - `| Filed |` (as table-row state)
  - `status changes to Amended`

## Forward-references

Some content (e.g. the `Record DIR Acknowledgement` dialog page) is referenced by name but not linked yet — those pages don't exist on `main`. Wave 3 will create them and add a cross-link back to this page.

## Closes

- #141 — VAT Returns state machine + terminology overhaul

## Out of scope

- New filing-wizard / Record DIR Acknowledgement / retract+payment pages → Wave 3 (#142, #143, #144)
- §32 sub-clause supply types + S3-005 blocked-poster → Wave 4 (#145)
- Attestation pathway reconciliation → Wave 5 (#146, gated on Cass call)
- Mechanical drift (Form 301, 10-point validation) → Wave 6 (#147, #148)

## Cross-reference

- Epic: #140
- Sibling Wave 1 PR: #151 (merged)
- Source-of-truth code paths cited in commit body
- VR-STATE-001 decision pack: Comply repo `tasks/comply/JULIAN-VR-STATE-001-DECISION-PACK-2026-05-25.md`
