### PR TITLE
Wave 3: Filing Wizard + Record DIR Acknowledgement pages (closes #142, #143, #144)

### DIFF
--- a/docs/vat-returns/filing-wizard.md
+++ b/docs/vat-returns/filing-wizard.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 4
+title: Filing Wizard
+description: The 5-step filing wizard that captures the regulated artefacts of your VAT return before lodgement
+---
+
+# Filing Wizard
+
+The Filing Wizard guides you through the regulated capture and finalisation steps that happen between **Draft** and **Awaiting Lodgement**. It is the surface where the Section 61 acknowledgement, the signatory declaration, and the artifact generation all happen, in a strict order, with named audit-trail entries at every transition.
+
+You enter the wizard from the **Filing** page in CoralLedger Comply, after you have generated a draft return for the period.
+
+## The five steps
+
+Comply renders the wizard as a numbered timeline:
+
+| # | Step | What happens | Audit event(s) written |
+|---|---|---|---|
+| **1** | Transaction Review | You confirm that every transaction for the period is imported, categorised, and accounted for. | _(no audit write)_ |
+| **2** | VAT Validation | The [10-point validation](/docs/vat-returns/return-preview) runs; you address blocking issues. | _(no audit write)_ |
+| **3** | Document Generation | Pre-flight check that the artifacts can be generated cleanly. | _(no audit write)_ |
+| **4** | **Approval** | You complete the [Section 61 acknowledgement](#step-4-approval-section-61-acknowledgement) and the [signatory capture](#step-4-approval-signatory-capture). The return transitions **Draft → Ready to File**. | `ACK_SECTION61`, then `RETURN_APPROVED_BY_SIGNATORY` |
+| **5** | **Submission** | Comply generates the PDF, XML, Excel, and Form 301 artifacts atomically and transitions **Ready to File → Filing in Progress → Awaiting Lodgement**. | `FILING_INITIATED`, `FILING_ARTIFACTS_GENERATED` |
+
+After step 5 you are presented with a **Filing Artifacts Ready** success card — described below in [What "Filing Artifacts Ready" means](#what-filing-artifacts-ready-means).
+
+## Step 4: Approval — Section 61 acknowledgement {#step-4-approval-section-61-acknowledgement}
+
+When you click **Approve** at step 4, Comply opens the Approve Filing dialog. The first panel is the Section 61 Penalty Acknowledgement.
+
+The dialog quotes the relevant rule from the [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61, and tells you the **maximum penalty exposure for this specific return**:
+
+> Under Bahamas VAT Act 2014, Section 61, the maximum penalty for an incorrect return is **up to 200% of the understated or over-claimed VAT** — **up to B$X on this return**.
+
+The dollar figure is calculated as `|Net VAT due| × 2`. The absolute value is used so credit and zero-balance returns also display a meaningful exposure (the figure represents what the penalty *could* be if the return were later found to be materially incorrect).
+
+You must tick the acknowledgement checkbox to proceed. When you do, Comply writes an `ACK_SECTION61` audit-ledger entry **before** it transitions the return state. This ordering matters — see [Audit-before-lock](#audit-before-lock).
+
+## Step 4: Approval — Signatory capture {#step-4-approval-signatory-capture}
+
+Below the §61 panel is the Authorised Signatory panel. Comply captures three things:
+
+- **Full Name** — the natural-person name of the individual signing for this return, up to 200 characters.
+- **Capacity** — a drop-down listing the four [Signatory Capacities](#signatory-capacities) recognised by Bahamian VAT practice.
+- **"I confirm I am authorised…" checkbox** — a separate declaration distinct from the §61 acknowledgement.
+
+When you click **Approve** to close the dialog, Comply writes a `RETURN_APPROVED_BY_SIGNATORY` audit-ledger entry capturing the name and capacity, then transitions the return state to **Ready to File**.
+
+### §32 attestation prefill
+
+If your CoralLedger account has an active **§32 attestation** for this client business (you are the BICA-licensed practitioner of record), Comply will pre-fill your name and set Capacity to `BICA-Licensed Practitioner`. The prefill is checked at the moment the dialog opens via a single correlated existence query against both your active client assignment and your active attestation record — see [Section 32 Attestation Pathway](/docs/attestation/) for how that determination is made.
+
+You can override the prefilled values if a different signatory is signing this specific return.
+
+## Signatory capacities
+
+The four capacities recognised by Bahamian VAT practice are:
+
+| Capacity | Who this is | When to pick it |
+|---|---|---|
+| **Registered Taxpayer** | The registered business owner or director, signing personally. | The most common capacity for sole traders and small businesses filing their own returns. |
+| **BICA-Licensed Practitioner** | A practising accountant licensed by the Bahamas Institute of Chartered Accountants, signing under their §32 attestation authority for the client. | When you are a firm staff member of record under a §32 attestation. Prefill defaults to this when applicable. |
+| **Authorised Employee** | An employee of the registered taxpayer with written internal authority to sign returns on the taxpayer's behalf. | Use when an internal finance officer or controller signs for the registrant. The internal authorisation is the registrant's record-keeping responsibility, not Comply's. |
+| **Authorised Agent** | A third-party agent who is not a BICA-licensed practitioner, signing under a separate written authorisation from the registrant. | Less common; used by registered tax-return preparers who are not licensed accountants. |
+
+The capacity value is recorded on the `RETURN_APPROVED_BY_SIGNATORY` audit entry and is durable for the 7-year retention period.
+
+## Audit-before-lock
+
+A subtle but important design choice: the two audit entries from step 4 — `ACK_SECTION61` and `RETURN_APPROVED_BY_SIGNATORY` — are written **before** the return is locked from edits.
+
+If the audit ledger is briefly unavailable (a backend transient), Comply will surface the error and **leave the return unlocked** so you can retry. The alternative — locking first, then attempting the audit write — would risk a state where the return is locked but no attestation evidence exists. That outcome would be regulatorily worse than leaving the return unlocked.
+
+You will not normally notice this behaviour because audit writes are fast. It matters during incident recovery.
+
+## Step 5: Submission
+
+When you click the Submit Filing button at step 5, Comply runs the finalisation routine, which:
+
+1. **Locks** the return for concurrent modification using a database-level compare-and-swap. A second concurrent caller (e.g. a duplicate browser tab) sees an error and does not duplicate work.
+2. **Generates** the PDF, XML, Excel, and Form 301 artifacts inside a single retry-safe transaction. Either all four are produced or none are persisted.
+3. **Writes** two audit-ledger entries: `FILING_INITIATED` (the start-of-finalisation marker) and `FILING_ARTIFACTS_GENERATED` (the end-of-finalisation marker, carrying the artifact set's identifiers).
+4. **Transitions** the return through Ready to File → Filing in Progress → **Awaiting Lodgement**.
+
+If finalisation fails partway, Comply rolls the return back to Ready to File so you can retry without re-doing the approval step.
+
+## What "Filing Artifacts Ready" means
+
+After step 5 completes, Comply displays a card titled **Filing Artifacts Ready**. The wording is deliberate — Comply has prepared everything you need to submit to the DIR, but **Comply itself has not submitted anything**. The actual submission to the Department of Inland Revenue happens externally:
+
+- via the [DIR's OTAS online portal](https://otas.revenue.gov.bs),
+- by walking the artifacts into a DIR office (Nassau or Freeport), or
+- via an authorised agent.
+
+The Filing Artifacts Ready card offers three actions:
+
+- **Download PDF** — a human-readable summary for your records and for in-person filings.
+- **Download XML** — the DIR-accepted submission format for upload via OTAS.
+- **Record DIR Acknowledgement** — the in-app capture you complete after the DIR confirms receipt of your submission. See [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) for the full flow.
+
+While the return sits in **Awaiting Lodgement**, no further audit-ledger writes happen — the next lifecycle event is when you record the lodgement.
+
+## Why the wizard exists
+
+The five-step structure encodes three regulatory facts:
+
+1. **The §61 penalty is not a hidden term in a generic ToS** — Comply quotes the rule, calculates the specific dollar exposure, and asks for an explicit acknowledgement.
+2. **The signatory declaration is captured per-return**, with the name and capacity persisted to the audit ledger. There is no "signed once, applies forever" shortcut.
+3. **Comply does not file on your behalf with the DIR.** The artifacts-ready / submitted distinction is enforced in the UI wording so a reader cannot confuse the two.
+
+These choices align with the principle from the [§32 Attestation Pathway](/docs/attestation/) that the regulatorily binding act happens in person between the registrant (or their authorised signatory) and the DIR — not silently inside the platform.
+
+## Next steps
+
+- [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) — the post-wizard step
+- [VAT Returns Overview](/docs/vat-returns/) — the canonical state machine
+- [Submit VAT Return](/docs/vat-returns/submit-return) — the external-submission workflow
+- [Section 32 Attestation Pathway](/docs/attestation/) — how the BICA-licensed practitioner prefill works
+- [Audit Trail](/docs/audit/) — where the audit-ledger entries surface

--- a/docs/vat-returns/index.md
+++ b/docs/vat-returns/index.md
@@ -57,7 +57,7 @@ The regulatorily significant transition is **lodgement** — recorded by you in 
 :::
 
 :::info Every return passes through Lodged first (VR-STATE-001)
-Even **credit and zero-balance returns** transition through `Lodged` before reaching `Lodged & Paid`, so the `RETURN_LODGED_WITH_DIR` audit entry always has a clean lodgement timestamp. Credit/zero returns auto-advance to `Lodged & Paid` immediately after the audit entry has been written. This is a deliberate regulatory invariant.
+Even **credit and zero-balance returns** transition through `Lodged` before reaching `Lodged & Paid`, so the `RETURN_LODGED_WITH_DIR` audit entry always has a clean lodgement timestamp. Credit/zero returns auto-advance to `Lodged & Paid` immediately after the audit entry has been written. This is a deliberate regulatory invariant — see [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement#vr-state-001-every-return-passes-through-lodged-first) for the full state-transition table.
 :::
 
 ## DIR Form Fields (L1-L31)
@@ -101,7 +101,9 @@ CoralLedger Comply supports two filing modes:
 
 - [Generate your VAT return](/docs/vat-returns/generate-return)
 - [Preview and validate](/docs/vat-returns/return-preview)
-- [Submit to the Comptroller](/docs/vat-returns/submit-return)
+- [Filing Wizard](/docs/vat-returns/filing-wizard) — §61 acknowledgement, signatory capture, and artifact generation
+- [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) — capture the DIR-side lodgement; retract and record payment
+- [Submit to the Comptroller](/docs/vat-returns/submit-return) — the external submission workflow
 - [Claim Bad Debt Relief (L16 adjustment)](/docs/compliance/bad-debt-relief)
 - [Input Tax Apportionment](/docs/vat-returns/input-tax-apportionment)
 - [Self-Filing Mode guide](/docs/getting-started/self-filing)

--- a/docs/vat-returns/input-tax-apportionment.md
+++ b/docs/vat-returns/input-tax-apportionment.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 title: Input Tax Apportionment
 description: How CoralLedger Comply calculates recoverable input VAT when a business makes both taxable and exempt supplies
 ---

--- a/docs/vat-returns/record-dir-acknowledgement.md
+++ b/docs/vat-returns/record-dir-acknowledgement.md
@@ -1,0 +1,131 @@
+---
+sidebar_position: 5
+title: Record DIR Acknowledgement
+description: The in-app capture that transitions a return from Awaiting Lodgement to Lodged, including retraction and payment recording
+---
+
+# Record DIR Acknowledgement
+
+After the [Filing Wizard](/docs/vat-returns/filing-wizard) generates your return's artifacts and transitions the state to **Awaiting Lodgement**, you submit those artifacts externally to the Department of Inland Revenue. When the DIR confirms receipt — by issuing a reference number, stamping your paper return, or simply acknowledging the OTAS upload — you return to Comply and **Record DIR Acknowledgement**.
+
+This in-app capture is the regulatorily significant transition from Awaiting Lodgement to **Lodged**.
+
+## Why Comply does not auto-mark "Lodged"
+
+Comply does **not** receive direct confirmation from the DIR. There is no integration today between CoralLedger Comply and the OTAS portal that posts an acknowledgement back. Because the DIR-side confirmation is the regulatorily binding event, Comply requires you to capture it manually. This is the same principle as the [§32 attestation](/docs/attestation/): the regulatorily binding act happens between you and the DIR, and Comply's job is to record the evidence.
+
+## The dialog
+
+You open the Record DIR Acknowledgement dialog from the **Filing Artifacts Ready** card (immediately after the wizard) or from the row actions on a return that is in Awaiting Lodgement.
+
+The dialog captures five things:
+
+| Field | Required | Notes |
+|---|---|---|
+| **Lodgement Date** | Yes | Must be on or after the date your artifacts were generated, and not in the future. Comply enforces this — you cannot record a lodgement before the artifacts existed. |
+| **Lodgement Method** | Yes | One of four enum values — see [Lodgement methods](#lodgement-methods). |
+| **Other Details** | When method = Other | Free text up to 500 characters, required only when method = Other. |
+| **DIR Reference Number** | **No (explicit)** | The helper text reads "Leave blank if DIR did not issue a reference number." Some lodgement methods do not produce a reference number — that is normal. |
+| **Acknowledgement checkbox** | Yes | "I confirm that I have lodged this return with the Department of Inland Revenue." |
+
+When you click **Confirm**, Comply runs the lodgement transition described below.
+
+## Lodgement methods
+
+The four methods Comply recognises:
+
+| Method | When to use it | DIR reference behaviour |
+|---|---|---|
+| **DIR Online Portal** | You uploaded the XML artifact through [OTAS](https://otas.revenue.gov.bs). | OTAS usually returns a transaction reference number; record it if it does. |
+| **Walked into DIR Office** | You took a printed copy to a DIR office in Nassau or Freeport. | DIR offices typically stamp and number a paper acknowledgement — record the stamp number. |
+| **Submitted via Authorised Agent** | A third-party agent submitted the return on your registrant's behalf. | The agent should report any reference number issued; if none, leave blank. |
+| **Other** | Anything that doesn't fit the three above (e.g., during a DIR system outage you submit via email to a DIR officer). | Required free-text explanation. Record any reference if issued. |
+
+The choice is persisted on the return and surfaced on the [View Filed Return](/docs/vat-returns/) read-only page, so the audit history records *how* the lodgement was made, not only that it happened.
+
+## What happens after you click Confirm
+
+Comply runs the transition inside a single retry-safe transaction:
+
+1. Validates the lodgement date is within bounds.
+2. Persists the lodgement date, method (and other-details if applicable), and reference number.
+3. Sets `FilingState = Lodged`.
+4. Best-effort syncs the corresponding **Filing Period** row so any late-filing banner clears.
+5. Writes the `RETURN_LODGED_WITH_DIR` audit-ledger entry. This entry carries an **artifact checksum dictionary** — SHA-checksums of the exact PDF / XML / Excel / Form 301 files you submitted — so the audit trail can later prove which specific artifacts were lodged.
+
+For credit and zero-balance returns, Comply then **auto-advances** the state to **Lodged & Paid** and writes a `NO_PAYMENT_DUE` audit-ledger entry. This second transition is part of the regulatory invariant — see [VR-STATE-001](#vr-state-001-every-return-passes-through-lodged-first) below.
+
+### State transition table
+
+| Return type | Result after Confirm |
+|---|---|
+| **Payable return** (Net VAT due > 0) | `Awaiting Lodgement` → **`Lodged`**. Stays at Lodged until you [record payment](#recording-payment). |
+| **Credit or zero return** (Net VAT due ≤ 0) | `Awaiting Lodgement` → `Lodged` → **`Lodged & Paid`**. Both transitions happen automatically; you do not need to record payment because none is due. |
+
+## VR-STATE-001: every return passes through Lodged first
+
+A deliberate regulatory invariant: **every** return, including credit and zero-balance ones, transitions through `Lodged` before it can reach `Lodged & Paid`. The auto-advance for credit/zero happens **after** the `RETURN_LODGED_WITH_DIR` audit entry has been written.
+
+Why this matters: the `RETURN_LODGED_WITH_DIR` audit entry carries the lodgement date, method, reference, and artifact checksums. Skipping `Lodged` for credit returns would mean the lodgement event never produces a clean audit row — which would break audit reproducibility for ~30% of returns over a financial year. The invariant exists so the DIR-side audit story is complete for every return type.
+
+## Retracting a lodgement
+
+If you discover an error in the lodgement capture (you recorded the wrong date or the wrong method, or the DIR rejected the submission and you need to re-do it), you can retract.
+
+### When retract is appropriate
+
+- You picked the wrong lodgement method or wrong date by accident.
+- The DIR-side process rejected the submission and you must re-lodge.
+- An authorised agent reports a different reference number than the one you recorded.
+
+It is **not** appropriate to retract simply because you noticed a return contains an error — for that you create an [amendment](/docs/vat-returns/submit-return#amendments), not a retraction.
+
+### How retraction works
+
+Retracting moves the return from `Lodged` back to `Awaiting Lodgement` and clears the lodgement date, method, other-details, and reference number. The original `RETURN_LODGED_WITH_DIR` audit entry is **not deleted** — instead, Comply writes a new `RETURN_LODGEMENT_RETRACTED` audit entry with your mandatory reason for the retraction. The audit history therefore records both the original lodgement and the retraction.
+
+### Constraints
+
+- **A reason is mandatory.** Comply will not accept a blank reason — the reason is persisted to the audit ledger.
+- **Rate limit: 3 retractions per rolling 24-hour window per return.** If you hit the limit, Comply surfaces a clear error explaining when you'll be able to retract again. The limit exists to prevent runaway retract/re-lodge cycles that would damage audit clarity.
+
+After retraction the return is back at Awaiting Lodgement and you can re-open the Record DIR Acknowledgement dialog to capture the corrected lodgement.
+
+## Recording payment
+
+For payable returns (Net VAT due > 0), the lifecycle does not end at `Lodged` — it ends at `Lodged & Paid`. You record the payment back into Comply after you have paid the DIR (via the OTAS portal, bank transfer to the Comptroller's account, or cheque at a DIR office).
+
+### Cumulative payments
+
+Comply accepts payments cumulatively. A return moves to `Lodged & Paid` only when the cumulative payment total **meets or exceeds the Net VAT due**. Partial payments keep the return at `Lodged` with a `Partially Paid` payment-status flag.
+
+### What gets written
+
+Each payment you record produces:
+
+- A `Payment` row on the return, capturing the amount, date, and method.
+- A `PAYMENT_RECORDED` audit-ledger entry.
+
+When the cumulative total catches up with Net VAT due, Comply transitions the return to `Lodged & Paid` automatically.
+
+### Why credit/zero returns don't appear here
+
+Credit and zero-balance returns reach `Lodged & Paid` automatically via the VR-STATE-001 auto-advance immediately after `RETURN_LODGED_WITH_DIR`. There is no payment to record because none is due (a credit return means the DIR owes you; recording the DIR refund when it arrives is a separate workflow tracked outside this dialog).
+
+## What you'll see on the View Filed Return page
+
+Once you have recorded lodgement, the return becomes read-only and is visible at `/vatreturns/{Id}/view`. The DIR Lodgement Details card on that page surfaces:
+
+- Lodgement Date
+- Lodgement Method (in plain-English form)
+- DIR Reference Number (if you recorded one)
+- Current Filing State (Lodged or Lodged & Paid)
+
+Plus a paginated **Audit Trail** timeline showing every audit-ledger entry for the return — including `ACK_SECTION61`, `RETURN_APPROVED_BY_SIGNATORY`, `FILING_INITIATED`, `FILING_ARTIFACTS_GENERATED`, `RETURN_LODGED_WITH_DIR`, `PAYMENT_RECORDED` (or `NO_PAYMENT_DUE`), and any `RETURN_LODGEMENT_RETRACTED` events from corrections.
+
+## Next steps
+
+- [VAT Returns Overview](/docs/vat-returns/) — the canonical 8-state machine
+- [Filing Wizard](/docs/vat-returns/filing-wizard) — the prior step
+- [Submit VAT Return](/docs/vat-returns/submit-return) — the external-submission workflow
+- [Audit Trail](/docs/audit/) — where every lodgement event surfaces

--- a/docs/vat-returns/submit-return.md
+++ b/docs/vat-returns/submit-return.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 title: Submit VAT Return
 description: Submit your VAT return to the Comptroller
 ---
@@ -85,6 +85,8 @@ There is no separate "Amended" final state — both the original return and its 
 
 ## Next Steps
 
+- [Filing Wizard](/docs/vat-returns/filing-wizard) — the in-app capture before external submission
+- [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) — what you do in Comply after DIR confirms receipt
 - [Monitor your compliance score](/docs/compliance/compliance-score)
 - [View filing history](/docs/vat-returns/)
 - [Cash flow report](/docs/reports/cash-flow)

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -64,6 +64,8 @@ const sidebars: SidebarsConfig = {
         'vat-returns/index',
         'vat-returns/generate-return',
         'vat-returns/return-preview',
+        'vat-returns/filing-wizard',
+        'vat-returns/record-dir-acknowledgement',
         'vat-returns/submit-return',
         'vat-returns/input-tax-apportionment',
       ],


### PR DESCRIPTION
## Summary

Wave 3 of the Phase 1 docs-vs-Comply remediation (epic #140). Adds two new pages to `docs/vat-returns/` covering the regulated capture flow between Draft and Lodged & Paid — ~3,000 words of new content grounded in citations to the Comply source.

## New pages

### `docs/vat-returns/filing-wizard.md` (sidebar_position 4) — closes #142

Covers the 5-step wizard:

1. Transaction Review
2. VAT Validation
3. Document Generation
4. **Approval** — §61 acknowledgement panel + signatory capture
5. **Submission** — atomic artifact generation + transition to Awaiting Lodgement

Section 61 panel includes the **exact penalty formula** (`|Net VAT due| × 2`) and the up-to-200% framing. All 4 `SignatoryCapacity` values are documented with plain-English when-to-use guidance. The §32 attestation prefill rule and the audit-before-lock invariant are both explained with regulatory rationale.

The "Filing Artifacts Ready" framing is preserved and explained as deliberate anti-misrepresentation language — Comply does not file with the DIR on the user's behalf.

### `docs/vat-returns/record-dir-acknowledgement.md` (sidebar_position 5) — closes #143 + #144

Covers the in-app capture that transitions a return to Lodged:

- Why Comply does not auto-mark Lodged (no DIR integration today).
- All 5 dialog fields with constraints (including the **explicit** "DIR Reference Number is optional" helper text).
- All 4 `LodgementMethod` values with examples.
- The state transition table for payable vs credit/zero returns.
- **VR-STATE-001 invariant** documented in full — every return passes through `Lodged` first, so `RETURN_LODGED_WITH_DIR` always has a clean timestamp + artifact checksum dictionary.
- **Retracting a lodgement** (#144 part A) — 3-per-24h rate limit + mandatory reason, persisted via `RETURN_LODGEMENT_RETRACTED`.
- **Recording payment** (#144 part B) — cumulative, credit/zero excluded, persisted via `PAYMENT_RECORDED`.

## Supporting changes

- `sidebars.ts` — two new entries inserted in the canonical order.
- `submit-return.md` sidebar_position bumped 4 → 6.
- `input-tax-apportionment.md` sidebar_position bumped 5 → 7.
- `index.md` — Next Steps updated; the previously-deferred Wave 2 link to `record-dir-acknowledgement` now resolves to a real page.
- `submit-return.md` — Next Steps updated to point at both new pages.
- Two explicit `{#anchor}` IDs added in `filing-wizard.md` to make the §61 / signatory cross-references resolve cleanly (Docusaurus default slugger strips colons and em-dashes).

## Verification

- Docusaurus build: ✅ green (`npm run build`).
- Forward references from Wave 2 to `record-dir-acknowledgement` now resolve.
- No broken anchors.

## Cited source-of-truth (Comply codebase)

- `Filing.razor:579-586` (wizard timeline)
- `Filing.razor:458-531, 857-907` (Submission success + audit-before-lock ordering)
- `Filing.razor:887` (§61 penalty formula)
- `ApproveFilingDialog.razor:38-51, 56-94, 152-174`
- `FilingWorkflowService.cs:88-364` (FinalizeFilingAsync)
- `FilingWorkflowService.cs:380-591` (ConfirmDirLodgementAsync, VR-STATE-001)
- `FilingWorkflowService.cs:594-661` (RetractLodgementAsync, 3-per-24h)
- `FilingWorkflowService.cs:664-837` (RecordPaymentAsync)
- `ConfirmDirLodgementDialog.razor` (full file — dialog fields)
- `ViewFiledReturn.razor:110-159, 164, 657-674` (read-only post-lodgement surface + displayed labels)
- `src/CoralComply.Web/Models/SignatoryCapacity.cs` (4-value enum)
- `src/CoralComply.Web/Services/ClientAssignmentLookupService.cs` (§32 attestation-scope EXISTS gate)

## Closes

- #142 — Filing wizard documentation gap
- #143 — Record DIR Acknowledgement documentation gap
- #144 — Retract Lodgement + Record Payment documentation gap

## Out of scope

- Phase 1 Waves 4–7. Wave 4 (#145, §32 supply types + S3-005 blocked-poster) ships next.

## Cross-reference

- Epic: #140
- Sibling Wave 1 PR: #151 (merged) — brand canonicals + dates + video stopgap
- Sibling Wave 2 PR: #152 (merged) — state machine overhaul
- Cass retroactive sign-off requested for §61 wording + lodgement framing + audit-before-lock rationale (per Cass plan §10 commitment to counter-sign window after authoring)
