### PR TITLE
Wave 5: Attestation pathway reconciliation — admin lifecycle vs per-return signatory declaration (closes #146)

### DIFF
--- a/docs/attestation/index.md
+++ b/docs/attestation/index.md
@@ -1,72 +1,113 @@
 ---
 sidebar_position: 1
 title: Section 32 Attestation Overview
-description: Overview of the Section 32 Attestation Pathway in CoralLedger Comply
+description: Two distinct §32 artefacts — the persistent firm-admin attestation lifecycle, and the per-return signatory capacity declaration
 ---
 
-# Section 32 Attestation Pathway
+# Section 32 Attestation Overview
 
-The Section 32 Attestation Pathway is a structured declaration process built into CoralLedger Comply that satisfies the formal attestation requirements under [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32. Before a VAT return can be submitted, the responsible party must pass through this pathway and confirm — under penalty of law — that the return is accurate and complete.
+CoralLedger Comply implements two distinct artefacts under the umbrella term "Section 32 attestation," and the distinction matters. Conflating them is the most common source of confusion when navigating this section.
 
-:::info Legal Basis
-[Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32 requires that every VAT return be accompanied by a signed declaration that the information provided is true, correct, and complete to the best of the declarant's knowledge and belief. CoralLedger Comply implements this requirement as a guided digital pathway.
+| Artefact | What it is | Where it lives | Lifecycle |
+|---|---|---|---|
+| **§32 Attestation Lifecycle (Firm Admin)** | A persistent practitioner statement, scoped to `(client, practitioner)`, that the practitioner has read the relevant variant body text and confirms understanding of the §32 sub-rules applicable to that client. | Created and managed through the firm-admin pathway. The persistent record sits behind `AttestationService`. | Create → potentially Supersede or Void. Persists across sessions until explicitly superseded. |
+| **Signatory Capacity Declaration (per return)** | A per-return declaration of who is signing the specific return being finalised, and in what authorised capacity. Backed by the `SignatoryCapacity` enum. | Captured in the **[Filing Wizard](/docs/vat-returns/filing-wizard) step 4** Approve Filing dialog, alongside the [Section 61 acknowledgement](/docs/vat-returns/filing-wizard#step-4-approval-section-61-acknowledgement). | A new declaration on every return. Recorded in the `RETURN_APPROVED_BY_SIGNATORY` audit event. |
+
+**The Signatory Capacity Declaration is not a §32 attestation.** It is a per-return capability declaration. Both artefacts can exist independently — and for some client/return combinations, both are required.
+
+:::info Which one do I need for this return?
+- If your client is in a **§3 restricted segment** (per Julian's CLR memorandum §3 — construction with retention, retainer-billed services, SaaS subscription, real-estate developers, and similar regulated categories), **you need both**: an `Active` §32 attestation in the persistent lifecycle, *and* the per-return Signatory Capacity Declaration at filing time.
+- If your client is **not** in a restricted segment, the per-return Signatory Capacity Declaration at filing time is sufficient on its own — no admin attestation is required.
+
+If you are unsure, see [Carve-Outs](/docs/attestation/carve-outs) for the restricted-segment determination.
 :::
 
-## Why Attestation Matters
+## Legal basis
 
-A VAT return submitted without a valid attestation is treated as incomplete by the Comptroller of Revenue. Consequences of an invalid or absent attestation include:
+> [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32, requires that every VAT return be accompanied by a signed declaration that the information provided is true, correct, and complete to the best of the declarant's knowledge and belief.
 
-- **Non-compliant filing status** — The return may be rejected or flagged
-- **Personal liability** — The declarant is personally accountable for the declaration
-- **Penalty exposure** — False declarations carry criminal and civil penalties under the VAT Act
-- **Audit risk** — Unsigned or improperly attested returns attract increased Comptroller scrutiny
+CoralLedger Comply satisfies this regulatory requirement through the combination of the two artefacts above: the persistent admin attestation lifecycle (where applicable) and the per-return Signatory Capacity Declaration (always).
 
-## Who Attests — Signatory Capacity
+A VAT return submitted without the relevant artefact(s) for that client is treated as incomplete by the Comptroller of Revenue. Consequences include non-compliant filing status, personal liability for the declarant, criminal and civil penalty exposure under the VAT Act, and increased Comptroller scrutiny.
 
-The attestation is completed by exactly one party per submission, identified by their **signatory capacity**. Comply recognizes four capacities, each backed by an enum value in the platform (`SignatoryCapacity`):
+## The §32 Attestation Lifecycle (Firm Admin)
 
-| Signatory capacity | Variant page | Who this is |
-|---|---|---|
-| **`RegisteredTaxpayer`** | [Standard Variant](/docs/attestation/variant-standard) | The registered business owner or director, attesting personally |
-| **`AuthorisedAgent`** | [Agent Variant](/docs/attestation/variant-agent) | A third-party agent acting on the registrant's behalf with a written authorization |
-| **`BicaLicensedPractitioner`** | [Professional Variant](/docs/attestation/variant-professional) | A BICA-licensed accountant attesting under one of the practice-area attestation bodies (Variants A / B / C / combinations — see Professional page) |
-| **`AuthorisedEmployee`** | [Digital Variant](/docs/attestation/variant-digital) *(coming soon)* | An authorized employee submitting with a qualified electronic signature; documented in advance for integrator planning, not yet available in the production platform |
+This is the section's main subject. It covers the persistent attestation record that a firm captures for a client business in a restricted segment.
 
-The [Qualifying Screen](/docs/attestation/qualifying-screen) determines which capacity applies based on the filer's role and the business's filing arrangement.
+### When the lifecycle applies
 
-:::note Variant vs Signatory Capacity
-The four variant pages map to the `SignatoryCapacity` enum. Within the Professional variant, the BICA-licensed practitioner additionally selects one of seven `AttestationVariant` bodies (Variant A — General VAT Compliance; Variant B — Return Preparation; Variant C — Advisory Services; and the four practice-area combinations A+B, A+C, B+C, A+B+C). See the [Professional Variant](/docs/attestation/variant-professional) page for details.
-:::
+A firm captures a §32 attestation for a client when:
 
-## Pathway Structure
+- The client is in a §3 restricted segment (so an attestation is required).
+- A BICA-licensed practitioner at the firm assumes responsibility for that client.
 
-The attestation process flows through the following stages:
+The attestation is then persisted against `(BusinessId, PractitionerUserId)` with `AttestationStatus = Active`. Until that record is superseded or voided, it governs all subsequent filings for that client.
 
-1. **Qualifying Screen** — Identifies the attestation variant applicable to the filer
-2. **Variant-Specific Declaration** — Presents the relevant declaration form based on the qualifier result
-3. **BICA Verification** *(where applicable)* — Confirms professional registration
-4. **Session Affirmation** — Confirms the current user's identity and intent mid-session
-5. **Handover** *(where applicable)* — Transfers attestation responsibility between parties
-6. **Submission** — Locks the return and records the attested event in the audit trail
+### Lifecycle operations
 
-## Carve-Outs
+- **Create** — A new attestation row is written when a practitioner first attests for a client. If a prior attestation exists, it is superseded in the same transaction (one Active record per pair).
+- **Supersede** — A new attestation replaces an existing one — for example, when the practitioner re-attests against an updated variant body text. The prior record's status moves to `Superseded` and a `SupersededAt` / `SupersededByAttestationId` link is recorded.
+- **Void** — An attestation is voided when the underlying client assignment changes, breaking the `(client, practitioner)` binding. The status moves to `VoidedByAssignmentChange`.
+- **Re-attestation required** — If the canonical body text drifts (detected via a `TextVersionHash` comparison), the existing attestation is considered insufficient and the practitioner is prompted to re-attest against the current text before they can post.
 
-Certain filings are exempt from the standard attestation pathway. See [Carve-Outs](/docs/attestation/carve-outs) for qualifying scenarios.
+Each operation writes a corresponding audit event (`ATTESTATION_CREATED`, `ATTESTATION_SUPERSEDED`, `ATTESTATION_VOIDED_BY_ASSIGNMENT_CHANGE`, `ATTESTATION_RE_ATTEST_REQUIRED`).
 
-## Audit Trail
+### Attestation bodies — Variants A / B / C and their combinations
 
-Every attestation event — including the variant selected, the declarant identity, timestamp, and session details — is recorded in an immutable audit log. See [Attestation Audit Trail](/docs/attestation/audit-trail) for details.
+Within the firm-admin lifecycle, a BICA-licensed practitioner attests under one of seven `AttestationVariant` bodies, each corresponding to a defined practice area or combination:
 
-## Next Steps
+| Code | Practice area covered |
+|---|---|
+| **Variant A** | General VAT Compliance Attestation |
+| **Variant B** | VAT Return Preparation Attestation |
+| **Variant C** | VAT Advisory Services Attestation |
+| **Variant A+B** | General Compliance + Return Preparation |
+| **Variant A+C** | General Compliance + Advisory Services |
+| **Variant B+C** | Return Preparation + Advisory Services |
+| **Variant A+B+C** | Full-scope attestation covering all three practice areas |
 
-- [Qualifying Screen](/docs/attestation/qualifying-screen)
-- [Standard Declaration Variant](/docs/attestation/variant-standard)
-- [Authorized Agent Variant](/docs/attestation/variant-agent)
-- [Professional Accountant Variant](/docs/attestation/variant-professional)
-- [Digital Filing Variant](/docs/attestation/variant-digital)
-- [BICA Verification](/docs/attestation/bica-verification)
-- [Session Affirmation](/docs/attestation/session-affirmation)
-- [Handover](/docs/attestation/handover)
-- [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) — what users see when attestation or assignment is revoked
-- [Carve-Outs](/docs/attestation/carve-outs)
-- [Attestation Audit Trail](/docs/attestation/audit-trail)
+Variants A, B, C, and A+B+C have ratified declaration bodies; the remaining three combinations (A+B, A+C, B+C) carry placeholder body text and require the practitioner to select one of the four ratified variants until ratification of the combinations is complete.
+
+The selected variant's body text is stored on the attestation record verbatim, along with the version hash, so the exact declaration is reproducible for the seven-year retention period.
+
+### Lifecycle sub-pages
+
+The pages below cover the firm-admin lifecycle in detail. They describe the structured declaration capture flow as originally specified.
+
+- [Qualifying Screen](/docs/attestation/qualifying-screen) — determining the applicable attestation variant
+- [Standard Variant](/docs/attestation/variant-standard), [Agent Variant](/docs/attestation/variant-agent), [Professional Variant](/docs/attestation/variant-professional) — the three primary variants
+- [Digital Variant](/docs/attestation/variant-digital) — see the page itself for current implementation status
+- [BICA Verification](/docs/attestation/bica-verification) — the BICA membership check that gates the Professional Variant
+- [Session Affirmation](/docs/attestation/session-affirmation) — identity re-confirmation mid-session
+- [Handover](/docs/attestation/handover) — transferring attestation responsibility (planned functionality)
+- [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) — what happens when the attestation or its underlying client assignment is revoked at run time
+- [Carve-Outs](/docs/attestation/carve-outs) — which client types fall outside the standard pathway
+- [Attestation Audit Trail](/docs/attestation/audit-trail) — the durable record of every lifecycle event
+
+## The Signatory Capacity Declaration (per return)
+
+This is the artefact that fires on every VAT return at the moment of finalisation, regardless of whether the client is in a restricted segment.
+
+The capture is documented in full at [Filing Wizard — Step 4 Approval](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture). In summary:
+
+- Captures **Full Name**, **Signatory Capacity** (from a 4-value enum), and a confirmation checkbox.
+- The four `SignatoryCapacity` values are `RegisteredTaxpayer`, `BicaLicensedPractitioner`, `AuthorisedEmployee`, and `AuthorisedAgent`. See the [filing wizard signatory section](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture) for plain-English guidance on when to pick each.
+- If the current user has an `Active` §32 attestation for this client business (per the admin lifecycle), the capture is **prefilled** with their name and `BicaLicensedPractitioner` capacity — an integration point between the two artefacts.
+- The result is persisted in the `RETURN_APPROVED_BY_SIGNATORY` audit event.
+
+A return cannot be finalised without a Signatory Capacity Declaration. For clients in a restricted segment, it cannot be finalised without an `Active` attestation either.
+
+## How the two artefacts relate
+
+The integration points between the firm-admin attestation lifecycle and the per-return Signatory Capacity Declaration are:
+
+1. **Prefill at filing time.** If the current user has an `Active` attestation for the client business, the Signatory Capacity Declaration prefills their name and capacity.
+2. **Posting gate at entry time.** The [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) blocks new transaction posting on a client when the user does not have both an active client assignment *and* an `Active` attestation — independent of any specific return.
+3. **Restricted-segment requirement.** For clients in a §3 restricted segment, both artefacts must be in place for a return to be lodged. For other clients, only the per-return Signatory Capacity Declaration is required.
+
+## Next steps
+
+- [Filing Wizard — Step 4 Approval](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture) — the per-return Signatory Capacity Declaration
+- [Qualifying Screen](/docs/attestation/qualifying-screen) — start of the firm-admin lifecycle
+- [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) — runtime enforcement
+- [Attestation Audit Trail](/docs/attestation/audit-trail) — durable record of lifecycle events

--- a/docs/attestation/variant-digital.md
+++ b/docs/attestation/variant-digital.md
@@ -1,92 +1,67 @@
 ---
 sidebar_position: 6
 title: Digital Filing Variant
-description: Section 32 attestation for returns submitted with a qualified electronic signature
+description: Planned future §32 attestation variant for filings signed with a qualified electronic signature — not yet in implementation scope
 ---
 
 # Digital Filing Variant
 
-:::warning Coming Soon — not yet available
-The Digital Filing Variant (qualified electronic signature) is **planned functionality** and is not yet available in the production platform. The settings path `Settings > Account > Digital Signing` referenced below has not yet been built; certificate registration, browser-based signing, and signature-verification flows are subject to change before launch. This page is published in advance so integrators can plan against the intended behavior. Until launch, use the [Standard](/docs/attestation/variant-standard), [Agent](/docs/attestation/variant-agent), or [Professional](/docs/attestation/variant-professional) variants.
+:::warning Not yet scoped for implementation
+The Digital Filing Variant is **planned but not yet scoped** for the §32 attestation admin lifecycle. The current `AttestationVariant` catalog contains seven codes — `A`, `B`, `C`, `AB`, `AC`, `BC`, `ABC` — covering the General Compliance, Return Preparation, and Advisory Services practice-area combinations. **There is no `D` code or "Digital" admin variant in the catalog today**, and no qualified-electronic-signature attestation body has been authored or ratified. The settings path `Settings > Account > Digital Signing` referenced below has not been built. This page is preserved as a forward-looking integrator-planning reference; the implementation date will be announced separately when the work is scoped.
 :::
 
-The Digital Filing Variant applies when the filer signs the VAT return using a **qualified electronic signature** backed by a recognized digital certificate. This variant meets the heightened signature requirements available to businesses that have provisioned a digital signing credential in CoralLedger Comply.
-
-## Who Uses This Variant
-
-This variant is presented when the [Qualifying Screen](/docs/attestation/qualifying-screen) determines that the filer is the business owner or director **and** has chosen the **qualified electronic signature** method. It may also be used by authorized agents who hold a valid digital certificate.
-
-A qualified electronic signature in this context means a signature produced using:
-
-- An X.509 digital certificate issued by a recognized Certificate Authority (CA)
-- A cryptographic private key held exclusively by the signing party
-- A signature algorithm supported by CoralLedger Comply (RSA-2048 or higher, ECDSA P-256 or higher)
-
-## Setting Up Digital Signing
-
-Before using this variant, a digital signing credential must be registered in CoralLedger Comply:
-
-1. Navigate to **Settings > Account > Digital Signing**
-2. Click **Register Certificate**
-3. Upload your X.509 certificate (PEM or DER format)
-4. CoralLedger Comply validates the certificate chain and expiry date
-5. Click **Confirm** — the certificate is now linked to your account
-
-:::warning Certificate Validity
-Certificates that are expired, self-signed, or issued by an unrecognized CA will be rejected at registration time and again at the point of signing. Keep your certificate up to date to avoid submission delays.
+:::info Do not confuse this with the `AuthorisedEmployee` Signatory Capacity
+The per-return [Signatory Capacity Declaration](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture) at filing time **does** accept `AuthorisedEmployee` as a live capacity value today. That is a different artefact — see [Section 32 Attestation Overview](/docs/attestation/) for the distinction between the firm-admin attestation lifecycle (which this page is part of) and the per-return Signatory Capacity Declaration (which is not). Selecting `AuthorisedEmployee` in the Approve Filing dialog is fully supported today and does **not** depend on the Digital Filing Variant described on this page.
 :::
 
-## Signing Flow
+The Digital Filing Variant, as originally specified, would apply when the filer signs the VAT return using a **qualified electronic signature** backed by a recognised digital certificate. This variant would meet heightened signature requirements available to businesses that have provisioned a digital signing credential in CoralLedger Comply.
+
+## Intended scope (forward-looking only)
+
+Once scoped and implemented, this variant would be presented when the [Qualifying Screen](/docs/attestation/qualifying-screen) determined that the filer is the business owner or director and has chosen the qualified electronic signature method. It may also be used by authorised agents who hold a valid digital certificate.
+
+A qualified electronic signature in this context would mean a signature produced using:
+
+- An X.509 digital certificate issued by a recognised Certificate Authority (CA).
+- A cryptographic private key held exclusively by the signing party.
+- A signature algorithm supported by CoralLedger Comply (RSA-2048 or higher, ECDSA P-256 or higher).
+
+## Intended setup flow (forward-looking only)
+
+Before using this variant, a digital signing credential would need to be registered in CoralLedger Comply:
+
+1. Navigate to **Settings > Account > Digital Signing** *(not yet built)*.
+2. Click **Register Certificate** *(not yet built)*.
+3. Upload your X.509 certificate (PEM or DER format).
+4. CoralLedger Comply validates the certificate chain and expiry date.
+5. Click **Confirm** — the certificate is linked to your account.
+
+## Intended signing flow (forward-looking only)
 
 When this variant is active:
 
-1. CoralLedger Comply generates a **return digest** — a SHA-256 hash of the return data package
-2. The return digest is displayed for review
+1. CoralLedger Comply generates a **return digest** — a SHA-256 hash of the return data package.
+2. The return digest is displayed for review.
 3. You sign the digest using your private key:
-   - **Browser-based signing** — Use the CoralLedger signing extension or a PKCS#11-compatible device (hardware token or smartcard)
-   - **File-based signing** — Download the digest, sign it offline with your certificate toolchain, and upload the signature file
-4. CoralLedger Comply verifies the signature against the registered certificate
-5. If verification passes, the declaration confirmation screen is shown
+   - **Browser-based signing** — using the CoralLedger signing extension or a PKCS#11-compatible device (hardware token or smartcard).
+   - **File-based signing** — download the digest, sign it offline with your certificate toolchain, and upload the signature file.
+4. CoralLedger Comply verifies the signature against the registered certificate.
+5. If verification passes, the declaration confirmation screen is shown.
 
-## Declaration Text
+## Intended declaration text (forward-looking only)
 
-After the signature is verified, the following declaration is presented:
+After signature verification, the following declaration would be presented:
 
-> *I declare that I have applied my qualified electronic signature to this VAT return, that I am the registered person or an authorized representative of the registered person named herein, and that the information provided in this return is, to the best of my knowledge and belief, true, correct, and complete. I understand that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32.*
+> *I declare that I have applied my qualified electronic signature to this VAT return, that I am the registered person or an authorised representative of the registered person named herein, and that the information provided in this return is, to the best of my knowledge and belief, true, correct, and complete. I understand that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32.*
 
-The filer confirms by checking **I confirm the above declaration** and clicking **Submit Return**. A password re-entry is not required for this variant because the cryptographic signature serves as the identity confirmation.
+The filer would confirm by checking **I confirm the above declaration** and clicking **Submit Return**. A password re-entry would not be required for this variant because the cryptographic signature would serve as the identity confirmation.
 
-## Validation Checks
+## Until launch — what to use today
 
-| Check | Condition |
-|-------|-----------|
-| **Certificate validity** | Certificate is not expired and is issued by a recognized CA |
-| **Signature integrity** | Signature matches the return digest and the registered certificate |
-| **Certificate binding** | Certificate is registered to the logged-in user account |
-| **Return completeness** | All mandatory return fields are populated |
-| **Period lock** | The tax period is open and not previously submitted |
-| **Session validity** | The attestation session has not expired |
+Until the Digital Filing Variant is scoped and implemented in the firm-admin attestation lifecycle, use the [Standard](/docs/attestation/variant-standard), [Agent](/docs/attestation/variant-agent), or [Professional](/docs/attestation/variant-professional) variants for capturing §32 attestations in the persistent admin lifecycle. At per-return filing time, the [Signatory Capacity Declaration](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture) is captured today via the Filing Wizard and supports all four `SignatoryCapacity` values — including `AuthorisedEmployee` — independently of this admin-side variant.
 
-## After Submission
+## Next steps
 
-Once the Digital Filing Declaration is accepted:
-
-- The return status changes from **Draft** to **Submitted**
-- The attestation record includes the certificate serial number, CA name, and signature hash
-- A submission receipt is generated and emailed to the address on file
-- The digital signature details are written to the [Attestation Audit Trail](/docs/attestation/audit-trail)
-
-## Advantages of the Digital Variant
-
-| Feature | Standard / Agent Variant | Digital Variant |
-|---------|--------------------------|-----------------|
-| Password re-entry required | Yes | No |
-| Signature verifiable offline | No | Yes |
-| Certificate-backed identity | No | Yes |
-| Suitable for headless filing pipelines | No | Yes |
-
-## Next Steps
-
-- [Session Affirmation](/docs/attestation/session-affirmation)
-- [Attestation Audit Trail](/docs/attestation/audit-trail)
-- [Submit your VAT return](/docs/vat-returns/submit-return)
+- [Section 32 Attestation Overview](/docs/attestation/) — the two distinct §32 artefacts explained
+- [Filing Wizard — Step 4 Approval](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture) — the per-return Signatory Capacity Declaration that is live today
+- [Standard Variant](/docs/attestation/variant-standard), [Agent Variant](/docs/attestation/variant-agent), [Professional Variant](/docs/attestation/variant-professional) — the three live attestation pathway variants

--- a/docs/vat-returns/filing-wizard.md
+++ b/docs/vat-returns/filing-wizard.md
@@ -48,9 +48,18 @@ When you click **Approve** to close the dialog, Comply writes a `RETURN_APPROVED
 
 ### §32 attestation prefill
 
-If your CoralLedger account has an active **§32 attestation** for this client business (you are the BICA-licensed practitioner of record), Comply will pre-fill your name and set Capacity to `BICA-Licensed Practitioner`. The prefill is checked at the moment the dialog opens via a single correlated existence query against both your active client assignment and your active attestation record — see [Section 32 Attestation Pathway](/docs/attestation/) for how that determination is made.
+If your CoralLedger account has an active **§32 attestation** for this client business (you are the BICA-licensed practitioner of record), Comply will pre-fill your name and set Capacity to `BICA-Licensed Practitioner`. The prefill is checked at the moment the dialog opens via a single correlated existence query against both your active client assignment and your active attestation record — see [Section 32 Attestation Overview](/docs/attestation/) for how that determination is made.
 
 You can override the prefilled values if a different signatory is signing this specific return.
+
+:::warning Is a §32 attestation also required for this return?
+The Signatory Capacity Declaration captured here is a **per-return** artefact — it is required on every return regardless of client type. It is **not** the same as a §32 attestation in the firm-admin lifecycle.
+
+- If your client is in a **§3 restricted segment** (per Julian's CLR memorandum §3 — construction with retention, retainer-billed services, SaaS subscription, real-estate developers, and similar regulated categories), the firm must **also** have an `Active` persistent §32 attestation for this `(client, practitioner)` pair before the return can be lodged. See [§32 Attestation Lifecycle (Firm Admin)](/docs/attestation/).
+- If your client is **not** in a restricted segment, the Signatory Capacity Declaration captured here is sufficient on its own.
+
+If you are unsure whether your client is in a restricted segment, see [Carve-Outs](/docs/attestation/carve-outs).
+:::
 
 ## Signatory capacities
 


### PR DESCRIPTION
## Summary

Wave 5 implements Cass's vote on #146: **Option B (admin/firm + user-flow split) with three refinements** (Cass call recorded 2026-05-30).

The previous `docs/attestation/` structure conflated two distinct regulatory artefacts under one term. This rewrite separates them and explains how they relate.

## Cass's three refinements — all implemented

**Refinement 1 — Artefact rename**
- Admin lifecycle: **§32 Attestation Lifecycle (Firm Admin)** — the persistent, supersedable record managed by `AttestationService`.
- Per-return capture: **Signatory Capacity Declaration** — not an attestation; a per-return capability declaration captured at the Filing Wizard step 4.

**Refinement 2 — Verify 'Digital Variant — coming soon'**
Verified against the Comply codebase before rewriting. Result:
- `AttestationVariant.All` catalog has **7 codes**: `A`, `B`, `C`, `AB`, `AC`, `BC`, `ABC`.
- **No `D` or 'Digital' code exists.**
- The 'Digital Variant — coming soon' callout was conceptually muddled — it claimed a future admin variant alongside the live `AuthorisedEmployee` SignatoryCapacity at the per-return capture.
- `variant-digital.md` is now reframed with two callouts: (a) top warning that the admin variant is not yet scoped (no D code in catalog), and (b) explicit distinction from the live `AuthorisedEmployee` Signatory Capacity at per-return capture (which is fully supported today).

**Refinement 3 — Explicit conditional cross-references**
Both surfaces now carry matching '§3 restricted segment?' callouts:
- `attestation/index.md` leads with a clear table mapping the two artefacts + an explicit 'which one do I need for this return?' callout explaining the §3-restricted-segment condition.
- `vat-returns/filing-wizard.md` mirrors the same condition pointing back to the admin lifecycle when needed.

## Files changed

- `docs/attestation/index.md` — full rewrite around the artefact-split table + integration-points section + relabel of the rest of the section as the firm-admin lifecycle
- `docs/attestation/variant-digital.md` — reframed; explicit clarification of admin variant (not yet scoped) vs live SignatoryCapacity
- `docs/vat-returns/filing-wizard.md` — conditional cross-reference warning added under the §32 attestation prefill section

## Out of scope (Cass workstream B follow-ups)

- Renaming the 'Signatory capture' section heading further (kept as-is for backwards anchor compatibility; canonical naming applied in the prose)
- Re-aligning Standard / Agent / Professional variant pages with the new artefact framing (those pages remain accurate for the admin lifecycle they document; minor cleanup is a follow-up)
- §3 vs §32 naming hygiene grep (sitewide grep returned 0 hits for '§3' in docs today; nothing to clean at present, but Cass flagged this folds into her broader Workstream B work)

## Verification

- Docusaurus build: ✅ green (`npm run build`)
- Refinement 2 implementation check: `AttestationVariant.All.Count == 7`, codes A/B/C/AB/AC/BC/ABC, no D or Digital — confirmed by unit-test catalog grep
- §3 hygiene baseline: `grep -i '§3\b' docs/` returns 0 hits

## Closes

- #146 — Attestation pathway docs vs code reconciliation

## Cross-reference

- Epic #140
- Cass's vote with refinements recorded in the #146 issue thread
- Sibling: practitioner-revocation page (Wave 4) already implements the runtime-enforcement story this rewrite establishes the framing for
