### PR TITLE
Wave 6: Form 301 export-format alignment + reduced sub-categories callout (closes #147, #148)

### DIFF
--- a/docs/getting-started/self-filing.md
+++ b/docs/getting-started/self-filing.md
@@ -101,7 +101,7 @@ Export your completed return for submission to the DIR's Online Tax Administrati
 
 1. Open the generated return
 2. Click **Export**
-3. Choose your preferred format — **PDF**, **XML**, **Excel**, or **CSV**
+3. Choose your preferred format — **PDF**, **XML**, **Excel**, or **Form 301**
 4. Submit the figures through the [DIR OTAS portal](https://otas.bahamas.gov.bs) or in person at a DIR office
 
 :::info OTAS Export

--- a/docs/vat-returns/generate-return.mdx
+++ b/docs/vat-returns/generate-return.mdx
@@ -61,10 +61,12 @@ Address any compliance alerts before finalizing your return. Critical alerts wil
 
 ### Step 5: Export
 Download your return in multiple formats:
-- **PDF** — For your records and client presentations
-- **XML** — DIR submission format
-- **Excel** — For detailed analysis
-- **CSV** — For data import into other systems
+- **PDF** — Human-readable summary for your records, in-person filings, and client presentations
+- **XML** — DIR-accepted submission format for upload via OTAS
+- **Excel** — Detailed analysis with calculated fields
+- **Form 301** — The structured DIR-specific submission artifact
+
+Transaction-level CSV exports (the underlying transactions, not the return itself) are available from the [Transactions](/docs/transactions/) listing page.
 
 ## Making Corrections
 

--- a/docs/vat-returns/index.md
+++ b/docs/vat-returns/index.md
@@ -23,10 +23,14 @@ VAT returns are due within **21 days** after the end of the tax period (14 days 
 Each VAT return includes:
 
 ### Output VAT (Sales)
-- Total taxable supplies at 10%
-- Total taxable supplies at 5%
-- Total zero-rated supplies
+- Total taxable supplies at 10% (**Standard** category)
+- Total taxable supplies at 5% (**Reduced** category)
+- Total zero-rated supplies (**Zero-Rated** category)
 - VAT collected from customers
+
+:::info Reduced (5%) sub-categories
+When you classify a transaction as **Reduced (5%)** in the [Manual VAT Entry](/docs/transactions/manual-entry) dropdown, Comply asks which sub-category applies — Food (licensed food stores only), Hygiene, Medical, or Essential Goods — so the legal-basis citation on the audit trail is precise. All four sub-categories ultimately compute at the 5% rate. See [VAT Rates Reference](/docs/reference/vat-rates) for the canonical category list and the food-store licensing rule.
+:::
 
 ### Input VAT (Purchases)
 - VAT paid on business purchases
@@ -76,9 +80,9 @@ Your return includes all standard Bahamas VAT return lines:
 - **Calculated Fields** - All L1-L31 fields computed from your transaction data
 - **Return Preview** - Review totals and validation before filing
 - **10-Point Validation** - Comprehensive pre-flight checks
-- **Export Formats** - PDF, XML, Excel, and CSV for electronic filing
-- **Amendment Support** - Correct filed returns with change tracking
-- **Multi-Format Export** - Download as PDF, XML, Excel, or CSV
+- **Export Formats** - PDF, XML, Excel, and Form 301 for DIR submission and your own records
+- **Amendment Support** - Correct lodged returns with change tracking
+- **Multi-Format Export** - Download a lodged return as PDF, XML, Excel, or Form 301
 
 ## Return Preview & Validation
 

--- a/docs/vat-returns/input-tax-apportionment.md
+++ b/docs/vat-returns/input-tax-apportionment.md
@@ -103,11 +103,12 @@ The full apportionment schedule is included in every return export:
 
 1. Open the VAT return for the relevant period
 2. Click **Export**
-3. Choose your preferred format: **PDF**, **Excel**, or **CSV**
+3. Choose your preferred format: **PDF**, **Excel**, **XML**, or **Form 301**
 4. The export includes the apportionment schedule:
    - **PDF** — displayed as a clearly labelled section within the return document
    - **Excel** — included as a dedicated **Input Tax Apportionment** worksheet
-   - **CSV** — included as separate rows with an `Apportionment` category label
+   - **XML** — embedded under the apportionment element of the DIR-accepted submission payload
+   - **Form 301** — included in the structured DIR submission artifact
 
 The exported schedule contains:
 


### PR DESCRIPTION
## Summary

Wave 6 of Phase 1 docs-vs-Comply remediation (epic #140). Mechanical drift fixes for two smaller items.

### #147 — Form 301 in the filed-return export list

`ViewFiledReturn.razor:110-159` renders **PDF / Excel / XML / Form 301** as the canonical filed-return artefact set. Docs previously claimed PDF / XML / Excel / **CSV** in three places — omitting Form 301 and including a CSV format that does not exist as a filed-return artefact.

- `docs/vat-returns/index.md` (2 hits in the Features list)
- `docs/vat-returns/generate-return.mdx` (Step 5 Export bullet — adds a pointer to the transaction-level CSV export which legitimately lives on the Transactions listing page)
- `docs/vat-returns/input-tax-apportionment.md` (apportionment schedule export)
- `docs/getting-started/self-filing.md` (Step 4 OTAS Export format dropdown)

Left unchanged: `docs/getting-started/index.md:40` 'Export Suite — PDF, XML, Excel, CSV, and Form 301 exports' — the only cross-cutting reference that legitimately covers both surfaces.

### #148 — Reduced (5%) sub-categories callout

`VATEntry.razor:459-465` exposes the 5% Reduced rate as four sub-categories: Reduced5Food (food-store licence required), Reduced5Hygiene, Reduced5Medical, Reduced5EssentialGoods. All four compute at 5% but carry distinct legal-basis citations on the audit trail.

`docs/vat-returns/index.md` now has an `:::info` callout under the Output VAT (Sales) section naming the four sub-categories and cross-linking to `vat-rates.mdx`.

### #148 — 10-point validation list verification

Verified against `FilingPreflightValidationService.ValidateAsync` (lines 128–137 in the Comply repo). The 10 `ValidateAsync` calls map 1:1 to the docs list on `docs/vat-returns/return-preview.md`. No docs change needed — baseline correct.

### #148 — secondary Comply repo issue filed

Filed caribdigital/coralledgercomply#3326 for the `VATCalculationValidator.cs:204` hardcoded error string drift ('must be 0%, 5%, or 10%' contradicting `ValidRates` which includes 7.5% / 12%). Out of scope for the docs repo; routed for Comply triage.

## Verification

- Docusaurus build: ✅ green
- Sitewide grep for `Excel.*or CSV` / `XML.*and CSV` / `CSV.*for electronic` in `docs/vat-returns/` returns 0 hits

## Closes

- #147 — Form 301
- #148 — 10-point validation + classification taxonomy

## Out of scope

- Comply-side fix for the validator error-string bug — tracked in caribdigital/coralledgercomply#3326
- Wave 7 (#149 demo videos) is moot — the underlying CDN issue was covered sitewide by #150 / Wave 1, and the Wave 7 stopgap is already live on `main`.

## Cross-reference

- Epic #140
- Sibling waves 1 (#151), 2 (#152), 3 (#153), 4 (#154), 5 (#155) — all merged