### PR TITLE
Strict rewrite: replace 'for electronic submission' with 'for OTAS upload' (closes #137)

### DIFF
--- a/docs/getting-started/self-filing.md
+++ b/docs/getting-started/self-filing.md
@@ -105,7 +105,7 @@ Export your completed return for submission to the DIR's Online Tax Administrati
 4. Submit the figures through the [DIR OTAS portal](https://otas.bahamas.gov.bs) or in person at a DIR office
 
 :::info OTAS Export
-The XML export is formatted specifically for electronic submission via OTAS. Use PDF for your own records and in-person filings.
+The XML export is formatted for OTAS upload — you submit it to the DIR through the OTAS portal yourself. Use PDF for your own records and in-person filings.
 :::
 
 ## When to Use Self-Filing Mode

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -38,8 +38,8 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         Generate VAT returns with 10-point pre-flight validation. Preview totals,
-        catch errors before filing, and export in PDF, CSV, or XML formats for
-        electronic submission.
+        catch errors before filing, and export in PDF, XML, Excel, or Form 301
+        formats ready for OTAS upload or in-person DIR filing.
       </>
     ),
   },


### PR DESCRIPTION
## Summary

Strict reading approved on #137 (2026-05-30). Two hits rewritten so the docs no longer carry the 'electronic submission' framing that implied Comply does the submitting to DIR.

## Changes

### `docs/getting-started/self-filing.md` — OTAS Export callout
> **Before:** The XML export is formatted specifically for electronic submission via OTAS. Use PDF for your own records and in-person filings.

> **After:** The XML export is formatted for OTAS upload — you submit it to the DIR through the OTAS portal yourself. Use PDF for your own records and in-person filings.

### `src/components/HomepageFeatures/index.tsx` — 'Validated Returns' card
> **Before:** ...catch errors before filing, and export in PDF, CSV, or XML formats for electronic submission.

> **After:** ...catch errors before filing, and export in PDF, XML, Excel, or Form 301 formats ready for OTAS upload or in-person DIR filing.

The card also picked up the **Wave 6 canonical-format alignment** — the old CSV reference is replaced by Excel + Form 301 (matching the four `ViewFiledReturn.razor` download buttons).

## Preserved

The safety baseline on `docs/vat-returns/index.md` (which states Comply does NOT receive direct DIR confirmation) is preserved unchanged.

## Verification

- Docusaurus build: ✅ green
- 'for electronic submission' grep across `docs/` + `src/` returns 0 hits

## Closes

- #137 — Electronic submission framing Cass call

## Cross-reference

- Epic #140
- Sibling Wave 6 PR #156 — canonical PDF / XML / Excel / Form 301 format set