### PR TITLE
DS-007: enumerate four VAT categories in Manual Override step (#138 sub-item B)

### DIFF
--- a/docs/transactions/categorization.md
+++ b/docs/transactions/categorization.md
@@ -59,7 +59,7 @@ You can always review and change suggested categories:
 1. Go to **Transactions**
 2. Select the transaction
 3. Click **Edit Category**
-4. Choose the correct VAT category
+4. Choose the correct VAT category — **Standard (10%)**, **Reduced (5%)**, **Zero-Rated (0%)**, or **Exempt** (see [VAT Rates](/docs/reference/vat-rates) for the canonical category list and the food-store licensing rule)
 5. Optionally add a note explaining the change
 
 ## Category Review


### PR DESCRIPTION
## Summary

Single-line content fix from #138 sub-item B. Cass-confirmed canonical DS-007 (`CASS-AUTHENTICITY-AUDIT-2026-05-07` master remediation plan).

`docs/transactions/categorization.md` Manual Override step 4 previously read 'Choose the correct VAT category' without enumerating the four categories. Updated to spell them out and cross-link to `reference/vat-rates`.

## Closes

Resolves DS-007 from the master remediation plan. Other sub-item B findings (DS-013/014/015) await Robbie surfacing `CLC-AUTHENTICITY-AUDIT-2026-05-07.md`.

## Cross-reference

- Epic #140
- Tracker #138