### PR TITLE
Wave 2.1: firm-client access traversal + landing page rewrite (closes #169, #162)

### DIFF
--- a/docs/firm-portal/firm-client-access.md
+++ b/docs/firm-portal/firm-client-access.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 2
+title: How Firm-to-Client Access Works
+description: The access traversal model that determines which clients a firm user can see and act on
+---
+
+# How Firm-to-Client Access Works
+
+When you sign in to the Firm Portal you see a grid of client businesses. This page explains the model behind which businesses appear in your grid — and why some clients you might expect to see may not be visible.
+
+The model matters because it is the foundation that every other Firm Portal capability builds on: client search, batch filing, reassignment, analytics, and the §32 attestation gates all read from the same access set.
+
+## The two ways you have access to a client
+
+CoralLedger Comply resolves your client list from two independent inputs:
+
+1. **Direct access** — you have a `UserBusinessAccess` row pointing at the client business. This is the explicit grant created when, for example, a client invites you to manage their books.
+2. **Firm self-business access** — you have access to your firm's "self-business" (the house account that represents the firm itself in Comply), and that firm self-business shares a `ManagingOrgId` with the client.
+
+The portal computes the union of both sets. A client appears in your grid if either path resolves to it.
+
+## The `ManagingOrgId` contract
+
+Every business in Comply has a `ManagingOrgId`. For a firm self-business and the firm's client businesses, the `ManagingOrgId` is the same. This is what links a firm to its clients without requiring an explicit grant on every client.
+
+| Business type | `ManagingOrgId` |
+|---|---|
+| Firm self-business (the house account) | The firm's own organisation id |
+| Each client business managed by that firm | Same as the firm self-business |
+| A standalone business with no firm | Its own organisation id (or null, depending on provisioning) |
+
+So when you have access to a firm self-business — by being on the firm's staff with a `UserBusinessAccess` row pointing at it — you implicitly gain visibility of every active client that shares its `ManagingOrgId`.
+
+## Walking the resolution
+
+When the Firm Portal loads your client grid:
+
+1. Comply looks up the `UserBusinessAccess` rows where `UserId == you`.
+2. From that set, it identifies any rows where the linked business has `IsFirmSelfBusiness = true` and `IsActive = true`.
+3. It collects those firm self-businesses' `ManagingOrgId` values.
+4. It pulls every active business whose `ManagingOrgId` is in that set — these are the "linked clients."
+5. It returns the union of (direct access businesses) ∪ (linked clients), restricted to active businesses, with their managing-org context for display.
+
+The same traversal runs on every per-business access check (e.g. "is this user allowed to open client X?"). Direct grants are checked first; if absent, the firm self-business traversal runs.
+
+## What this means in practice
+
+### When you're added to a firm
+
+A firm administrator grants you `UserBusinessAccess` to the firm self-business. From the next time you load the portal, every active client of that firm appears in your grid — no per-client grant required.
+
+### When you're removed from a firm
+
+Your `UserBusinessAccess` row pointing at the firm self-business is revoked. From the next portal load, every client of that firm disappears from your grid — again, without needing per-client revocation.
+
+### When a client is archived or deactivated
+
+`IsActive` flips to false. The traversal excludes inactive businesses, so the client immediately drops out of your grid (and out of analytics, batch filing, etc.).
+
+### When a firm's clients are reassigned across staff
+
+Per-staff assignment lives on the `ClientAssignment` entity (workload distribution) — a layer above access. You can have firm-portal access to a client (and see it in the grid) without being its currently-assigned practitioner. See [User Management](/docs/firm-portal/user-management) for the workload-assignment surface and §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ for how attestation interacts with reassignment.
+
+## Access vs §32 attestation — different gates
+
+This page is about **access control** — what you can see and act on at the Firm Portal level. It is distinct from the **§32 attestation scope gate** that runs on attestation-sensitive surfaces (transaction posting, signatory prefill).
+
+| Gate | Question it answers | Where it lives |
+|---|---|---|
+| **Firm-to-client access** (this page) | Can this user see and act on this client at the firm-portal level? | `BusinessService.ValidateUserAccess` / `GetUserBusinesses` |
+| **§32 attestation scope** | Is this user the regulated practitioner-of-record for this client? (Active `ClientAssignment` AND Active `Attestation`.) | `ClientAssignmentLookupService.LookupAsync` |
+
+Having Firm Portal access to a client does **not** make you the practitioner-of-record for that client. The reverse is also true — being the practitioner-of-record assumes you have Firm Portal access (otherwise you couldn't navigate to the client), but the two are evaluated independently. The [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) covers what users see when the attestation gate fires.
+
+## Multi-tenant safety properties
+
+The traversal is enforced server-side, not in the UI:
+
+- `IsActive` gate excludes archived businesses from both the firm self-business set and the linked clients set.
+- `ManagingOrgId` match enforces the firm boundary — a user with access to firm A's self-business cannot see firm B's clients, even if both firms exist in the same Comply tenant.
+- Queries run as `AsNoTracking()` reads — no inadvertent change-tracker capture, no cross-request entity state.
+
+These properties match the project's mandatory rule that every database query filters by the multi-tenant boundary.
+
+## Next steps
+
+- [Firm Portal Landing](/docs/firm-portal) — what the resolved client set looks like in the dashboard
+- §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ — the regulatory-authority gate that runs *in addition to* access control
+- [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) — runtime enforcement when the §32 gate fires
+- [User Management](/docs/firm-portal/user-management) — how `UserBusinessAccess` rows are created and revoked

--- a/docs/firm-portal/index.mdx
+++ b/docs/firm-portal/index.mdx
@@ -6,7 +6,7 @@ description: Manage multiple client businesses in CoralLedger Comply
 
 # Firm Portal
 
-The Firm Portal enables accounting professionals to manage VAT compliance for multiple client businesses.
+The Firm Portal is the central surface for accounting professionals managing VAT compliance across multiple client businesses. It exposes the firm-wide dashboard, the client grid with search, batch and per-client filing surfaces, multi-client reporting, staff productivity, and (where applicable) the §32 attestation entry pathway for restricted-segment clients.
 
 ## Client Management Walkthrough
 
@@ -18,75 +18,97 @@ Demo recordings of this workflow will be added here. Topics:
 - Batch filing workflow
 :::
 
-## Who Should Use Firm Portal?
+## Who uses the Firm Portal
 
-- **Accounting Firms** - Managing client VAT compliance
-- **Bookkeepers** - Handling multiple business clients
-- **Tax Professionals** - Preparing client VAT returns
+- **Accounting firms** managing client VAT compliance under a single firm umbrella
+- **Bookkeepers** handling multiple business clients on a shared team
+- **Tax professionals** preparing and lodging client VAT returns
 
-## Features
+Each of these workflows is shaped by the same access traversal — see [How Firm-to-Client Access Works](/docs/firm-portal/firm-client-access) for the model that determines which clients appear in your grid.
 
-### Multi-Client Dashboard
-- View all clients at a glance
-- Aggregate compliance scores
-- Prioritized action items
-- Deadline tracking across clients
+## The dashboard at a glance
 
-### Client Management
-- Add and remove client businesses
-- Set up client business profiles
-- Manage client users and permissions
-- Transfer clients between staff
-- **Client invitations** — send, resend (token refresh), and revoke invitations with a 7-day expiry lifecycle
+The Firm Portal landing page renders **seven KPI cards** drawing on aggregate data across every active client your account has access to. The cards are designed to surface the highest-stakes items first.
 
-### Batch Operations
-- Import transactions for multiple clients
-- **Batch filing** - File multiple returns in one workflow
-- Generate aggregated reports
-- Bulk client import via CSV
+| Card | What it shows | Notes |
+|---|---|---|
+| **Total Clients** | Count of active client businesses in your access set | Excludes archived clients |
+| **Pending Filings** | Count of returns in `ReadyToFile` / `AwaitingDirConfirmation` state across clients | Bridges to [Filing Wizard](/docs/vat-returns/filing-wizard) |
+| **Pending Re-attestations** | Count of clients with no active §32 attestation or with a stale attestation (text-drift detected) | **Clickable** — links to the client grid pre-filtered to `?filter=pending-reattestation`. Surfaces the §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ for the firm administrator |
+| **Compliance Score** | Aggregate firm compliance health with High / Medium / Low / Not-Assessed chips | Computed from per-client compliance scores |
+| **Portfolio Net VAT** | Sum of net VAT due / refundable across the period | Negative if the portfolio is a net refund |
+| **Returns Filed This Quarter** | Count of returns that reached `Lodged` or `Lodged & Paid` in the current quarter | See the [canonical lifecycle](/docs/vat-returns/#return-lifecycle) for state definitions |
+| **Next Deadline** | Countdown to the next filing deadline across your portfolio | Displays an overdue overlay if any return is past its deadline |
 
-### Firm Analytics
-- Cross-client compliance trends
-- Aggregate VAT metrics
-- Staff productivity tracking
-- Performance benchmarks
+:::warning Pending Re-attestations is regulatorily significant
+The `Pending Re-attestations` count is the firm-administrator's view of clients that cannot currently be filed for under the §32 pathway. Clicking it opens the client grid filtered to those clients so each can be routed through the §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_. Treat a non-zero count as actionable work, not a status indicator.
+:::
 
-### Team Collaboration
-- Assign clients to team members
-- Track work status and time
-- Review and approve returns
-- ROI calculator
-- Audit trail of all actions
+## Quick actions
 
-## Getting Started
+The Quick Actions row sits below the KPI cards and offers four navigation shortcuts plus a refresh:
 
-### Adding a Client
-1. Go to **Clients > Add New**
-2. Enter client business details
-3. Set up TIN and VAT number
-4. Invite client users via **Invite Client** — see [Client Invitation Lifecycle](/docs/firm-portal/user-management#client-invitation-lifecycle)
+| Button | Destination |
+|---|---|
+| **Add Client** | `/firm/clients/onboard` — see [Adding a client](#adding-a-client) below |
+| **Batch VAT Filing** | `/firm/batch-filing` — see [Batch Filing](/docs/firm-portal/batch-filing) |
+| **Multi-Client Reports** | `/firm/reports` — see [Firm Analytics](/docs/firm-portal/analytics) |
+| **Staff Productivity** | `/firm/productivity` — workload distribution + per-staff metrics |
+| **Refresh** | Reloads dashboard data without leaving the page |
 
-### Managing Permissions
-- **Full Access** - Can import, edit, generate returns
-- **View Only** - Can view but not modify
-- **Review Only** - Can approve returns only
+## The client grid
 
-## Subscription Tiers
+Below the KPI cards and Quick Actions, the Firm Portal renders a paginated **client businesses grid** with columns BusinessName, TIN, VAT#, Status, FilingFrequency, ComplianceScore, NetVAT, NextFilingDue, LastActivity, and Actions. Each row exposes per-client navigation (View Dashboard / VAT Returns / Import Transactions).
+
+### Finding clients
+
+The client grid supports search across the **business name, TIN, and VAT number** columns. Type at least **two characters** in the search input above the grid; results filter live with a short (300 ms) debounce, and a screen-reader-friendly live region announces "N clients match" alongside the result count.
+
+The search composes with the **Filing Frequency filter** (All / Monthly / Quarterly) — both apply together. The grid paginates and sorts server-side.
+
+If no clients match, an empty-state panel describes the active filters so you know whether to broaden your search or clear the filing-frequency filter.
+
+The search is being extended with additional matching modes (fuzzy / tokenised) tracked under [Comply #3125](https://github.com/caribdigital/coralledgercomply/issues/3125). The current shipped behaviour described above is stable.
+
+## Adding a client
+
+From the Firm Portal landing, click the **Add Client** quick action (or the Add Client button on the Clients grid). This opens the Client Onboarding wizard at `/firm/clients/onboard`.
+
+The wizard captures six structured sections (Business Identification, VAT Configuration, Contact + Billing, Address, Engagement, conditional Food Store License). It is gated to **firm Owners only** — non-Owners cannot onboard clients.
+
+See Client Onboarding _(detailed page coming in Wave 2.2)_ for the full capture sequence, the validation rules, and what onboarding does *not* do (specifically: it does not create a §32 attestation; that is a separate step for restricted-segment clients).
+
+## Managing permissions
+
+The Firm Portal recognises two base permission levels — **Owner** and **Accountant**. Non-Owner access is further refined via the **granular permission matrix**, which lets an Owner toggle per-category access (Transactions, Reports, Compliance, Settings, User Management, Security) for any Accountant user.
+
+There is no separate "View Only" or "Review Only" tier as a named third level — a read-only experience is achieved via granular permissions on an Accountant.
+
+See [User Management](/docs/firm-portal/user-management) for the canonical permission reference, the Last-Owner protection, and the client invitation lifecycle.
+
+## §32 attestation in the Firm Portal
+
+The Firm Portal is the entry point for the firm-administrator side of the §32 attestation lifecycle. The `Pending Re-attestations` KPI card surfaces clients that need attention; clicking through routes you to the §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_, which walks a practitioner through the carve-out qualifying screen and the regulatory acknowledgement modal that ultimately writes the `ATTESTATION_CREATED` audit event.
+
+The lifecycle states themselves (Active / Superseded / VoidedByAssignmentChange) and the relationship to the per-return Signatory Capacity Declaration are documented separately at [Section 32 Attestation Overview](/docs/attestation/).
+
+## Subscription tiers
 
 :::info Free Beta — Open Beta in progress
 All Firm Portal features are available at no cost during open beta. Subscription billing begins after open beta.
 :::
 
 | Tier | Max Clients | Price | Notes |
-|------|-------------|-------|-------|
+|---|---|---|---|
 | **Founding Member** | 25 | $99/mo | Locked for life — limited to 20 spots |
 | **Accounting Firm** | 25 | $499/mo | Standard pricing |
 | **Enterprise** | Unlimited | Custom | Dedicated support, SLA |
 
-## Next Steps
+## Next steps
 
-- [Set up your first client](/docs/getting-started/setup-business)
-- [Use batch filing](/docs/firm-portal/batch-filing)
-- [View firm analytics](/docs/firm-portal/analytics)
-- [Manage team members](/docs/firm-portal/user-management)
-- [Import client transactions](/docs/transactions/import-csv)
+- [How Firm-to-Client Access Works](/docs/firm-portal/firm-client-access) — the access model that resolves your client set
+- Client Onboarding _(detailed page coming in Wave 2.2)_ — the 6-section wizard for adding a client
+- §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ — what to do for restricted-segment clients
+- [Batch Filing](/docs/firm-portal/batch-filing) — file multiple returns in a single workflow
+- [Firm Analytics](/docs/firm-portal/analytics) — cross-client trends and staff productivity
+- [User Management](/docs/firm-portal/user-management) — permissions, granular access, and the client invitation lifecycle

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -139,6 +139,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'firm-portal/index',
+        'firm-portal/firm-client-access',
         'firm-portal/batch-filing',
         'firm-portal/analytics',
         'firm-portal/user-management',


### PR DESCRIPTION
## Summary

First execution wave of Phase 2 (epic #161). Lands the access traversal model + rewrites the Firm Portal landing page. These ship together because the landing rewrite depends on the access model being explained.

## New page — docs/firm-portal/firm-client-access.md

Explains the BusinessService firm-to-client access traversal from Comply PR #3299 / Comply issue #792. Covers:

- The two access paths (direct UserBusinessAccess vs firm self-business via shared ManagingOrgId)
- Step-by-step traversal walk for portal load + per-business access check
- Practical scenarios (added to firm, removed from firm, archived client, reassigned client)
- The critical distinction from §32 attestation scope gate — this is access control, not regulatory authority. Cross-link to the practitioner-revocation runtime gate (Wave 4)
- Multi-tenant safety properties (IsActive gate, ManagingOrgId boundary, AsNoTracking server-side reads)

## Rewrite — docs/firm-portal/index.mdx

- **7 named KPI cards** documented by name + backing source + special-cased Pending Re-attestations callout (regulatorily significant)
- **Quick Actions row** documented with exact destinations
- **Client grid + search** using Cass framing rule ('supports X today' / 'Y being added' with Comply #3125 handle)
- **Permission levels corrected** — Owner / Accountant + granular permission matrix (the prior 'Full Access / View Only / Review Only' tiers as named do not exist)
- **Adding a Client** trimmed to a pointer; full onboarding details in Wave 2.2 (#163)
- **§32 attestation in the Firm Portal** intro added; full pathway in Wave 2.2 (#164)

## Forward references marked, not broken

Cross-references to two pages that don't exist yet (client-onboarding, attestation-entry-pathway) appear as 'documentation coming in Wave 2.2' rather than broken links. Wave 2.2 will create those pages and add the cross-links back.

## Verification

- Docusaurus build: green
- Resurrection-grep guards (sitewide):
  - 'Full Access|View Only|Review Only' as permission-tier names — 0 hits
  - 'Caribbean Digital Labs' — 0 hits
  - 'support@coralledger.com' — 0 hits

## Closes

- #162 — Firm Portal landing page rewrite
- #169 — Firm-to-client access traversal documentation

## Cross-reference

- Phase 2 epic: #161
- Underlying Comply PR: #3299
- Cass scoping criteria 2026-05-30 (driving the inline-cross-link decisions for INDIRECT class pages)
- Cass retroactive sign-off requested for the Pending Re-attestations regulatory-significance callout wording