### PR TITLE
Wave 2.2: §32 entry pathway + client onboarding + user-management cleanup (closes #164, #163, #167)

### DIFF
--- a/docs/firm-portal/attestation-entry-pathway.md
+++ b/docs/firm-portal/attestation-entry-pathway.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 5
+title: Section 32 Attestation Entry Pathway
+description: The firm-side three-stage pathway that produces an Active §32 attestation for a restricted-segment client
+---
+
+# Section 32 Attestation Entry Pathway
+
+For clients in a §3 restricted segment (per Julian's CLR memorandum §3 — construction with retention, retainer-billed services, SaaS subscription, real-estate developers, and similar regulated categories), CoralLedger Comply requires an `Active` §32 attestation before a return can be lodged. This page describes the **firm-side pathway** that creates that attestation.
+
+The pathway runs **once per `(client, BICA-licensed practitioner)` pair**. Once an attestation is `Active`, subsequent returns for that client reuse it — see [Section 32 Attestation Overview](/docs/attestation/) for the full lifecycle reference.
+
+:::info This is the only Razor path that creates an attestation
+The Regulatory Acknowledgement modal at the end of this pathway is the only user-facing surface in Comply that writes the `ATTESTATION_CREATED` audit event. Other lifecycle events (`ATTESTATION_SUPERSEDED`, `ATTESTATION_VOIDED_BY_ASSIGNMENT_CHANGE`) reach the audit ledger today only via API-side flows or implicitly via this pathway.
+:::
+
+## Where this pathway lives
+
+| Stage | Route | Surface |
+|---|---|---|
+| 1 — Carve-out qualification | `/firm/clients/{ClientId}/attest` | Carve-Out Qualifying Screen |
+| 2 — Modal capture | `/clients/{id}?beginAttestation=true` | Regulatory Acknowledgement Modal (hosted by Client Details) |
+| 3 — Persisted | _(server-side)_ | `AttestationService.CreateAttestationAsync` writes the row + the audit event |
+
+You enter the pathway from the Firm Portal landing's `Pending Re-attestations` KPI card (which filters the client grid to the affected clients) or from a client's row action when their attestation is missing or stale.
+
+## Stage 1 — Carve-out Qualifying Screen
+
+The qualifying screen asks two questions to determine whether the client falls into a **hard-refusal carve-out** before the practitioner invests time in the modal.
+
+If the practitioner's answers indicate a carve-out scenario:
+
+- The screen presents a **Record Deferral & Return to Client** action.
+- Clicking it persists a `CarveOut` evaluation against the client.
+- The carve-out blocks attestation creation for this client. No `ATTESTATION_*` event fires.
+- The practitioner returns to the client's dashboard without attesting.
+
+If the answers indicate a clear assessment:
+
+- The screen presents a **Proceed to Attestation** action.
+- Clicking it navigates to `/clients/{id}?beginAttestation=true`, which auto-opens the Regulatory Acknowledgement modal on the Client Details page.
+
+The two-question shape and the carve-out scenarios themselves are tracked separately in the canonical §32 SPEC. The qualifying screen is the gate that enforces the SPEC's hard-refusal rule.
+
+## Stage 2 — Regulatory Acknowledgement Modal
+
+The modal is hosted by the Client Details page (`ClientDetails.razor` auto-opens it when the `?beginAttestation=true` query parameter is present). It is the actual capture surface for the §32 attestation.
+
+The modal exposes four actions:
+
+| Action | What it does | Audit event |
+|---|---|---|
+| **Verify BICA** | Calls the BICA registry verification (or the documented manual-fallback path) to confirm the practitioner's BICA licence | BICA-side event (not part of the §32 lifecycle) |
+| **Submit / Sign Attestation** | Calls `AttestationService.CreateAttestationAsync` to persist the attestation row and write the lifecycle audit event | **`ATTESTATION_CREATED`** (+ implicit `ATTESTATION_SUPERSEDED` if a prior `Active` row existed for the same `(BusinessId, PractitionerUserId)`) |
+| **Cancel / Close** | Closes the modal without creating the attestation; records the cancellation for audit hygiene | `ATTESTATION_MODAL_CANCELLED` |
+| **Notify me when ready** (unauthored-variant path) | Closes the modal with a deferred-completion intent | `ATTESTATION_MODAL_CANCELLED` |
+
+`ATTESTATION_MODAL_CANCELLED` is a hygiene event — it captures user intent ("I started attestation but did not complete it"), not a lifecycle transition. The next attempt at attestation runs fresh.
+
+## Stage 3 — What gets persisted
+
+When the practitioner clicks **Submit**, `AttestationService.CreateAttestationAsync` runs inside a single retry-safe transaction:
+
+1. If a prior `Active` attestation exists for the same `(BusinessId, PractitionerUserId)`, it is moved to `Superseded` status with `SupersededAt` set + the new attestation id linked.
+2. The new attestation row is persisted with `AttestationStatus = Active`, the captured variant body text (verbatim), and a `TextVersionHash` computed from `BodyId|Version|BodyText`.
+3. BICA-licence metadata is captured (number, verification status, verified-at timestamp, practitioner name).
+4. The `ATTESTATION_CREATED` audit-ledger entry is written best-effort post-commit (per the project's "DB row is persisted; ledger entry missed" pattern documented for the audit ledger).
+
+The practitioner is returned to the Client Details page. The Pending Re-attestations count on the Firm Portal landing drops by one for this client.
+
+## What this pathway does NOT do
+
+The pathway covers attestation creation for the current `(client, practitioner)` pair. It does **not** cover:
+
+- **Explicit supersession** via `AttestationService.SupersedeAsync` — that method exists in the service layer but has no Blazor UI caller today. Supersession reaches the audit ledger only implicitly, via Create-superseding-a-prior-Active.
+- **Explicit voiding** via `AttestationService.VoidAsync` (single-attestation) — also no UI caller; reached only via the batch path below.
+- **Batch voiding on reassignment** via `WorkloadDistributionService.ReassignClientAsync` → `AttestationService.VoidAttestationsAsync` — invoked **today** only by the `AccountingFirmController` API endpoint, not by any Blazor UI. The Clients grid row action "Reassign practitioner" is a coming-soon UI stub.
+
+So if you are reading audit-trail entries that include `ATTESTATION_SUPERSEDED` or `ATTESTATION_VOIDED_BY_ASSIGNMENT_CHANGE` events, those entries were produced either implicitly by a re-attestation through this pathway or by an API-driven reassignment, not by a button on a Comply page that an end user clicked.
+
+## Read-side state discovery is separate
+
+The `ATTESTATION_RE_ATTEST_REQUIRED` event also exists in the audit ledger. It is **not** written by this pathway — it is written by the read-side check (`AttestationService.IsReAttestationRequiredAsync`) when the page-load lookup detects either:
+
+- No `Active` attestation for the `(client, practitioner)` pair
+- An `Active` attestation whose `TextVersionHash` no longer matches the current canonical body text
+
+The check fires from the Client Details page load and from the Firm Portal landing's Pending Re-attestations count. Treat it as **state-discovery**, not state-transition.
+
+## When this pathway is required
+
+The pathway runs when:
+
+- The client is in a §3 restricted segment (per Julian's CLR memorandum §3); AND
+- There is no `Active` attestation for the current practitioner against that client; OR
+- The existing `Active` attestation's body text has drifted (re-attestation required).
+
+For clients not in a restricted segment, only the **per-return Signatory Capacity Declaration** at filing time is required — captured in the [Filing Wizard](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture), not here. See [Section 32 Attestation Overview](/docs/attestation/) for the distinction between the two artefacts.
+
+## Next steps
+
+- [Section 32 Attestation Overview](/docs/attestation/) — the lifecycle reference (states, integration points, when each artefact applies)
+- [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) — runtime enforcement when the attestation gate fires on transaction posting
+- [Filing Wizard](/docs/vat-returns/filing-wizard) — the per-return Signatory Capacity Declaration that runs on every return
+- [Firm Portal](/docs/firm-portal/) — the Pending Re-attestations KPI card that surfaces clients needing this pathway

--- a/docs/firm-portal/client-onboarding.md
+++ b/docs/firm-portal/client-onboarding.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 3
+title: Client Onboarding
+description: The six-section wizard for adding a new client business to the firm — Owner-only, with explicit framing of what onboarding does and does not do
+---
+
+# Client Onboarding
+
+Client Onboarding is the firm-side wizard at `/firm/clients/onboard` that creates a new client business under the firm's management. You reach it from the **Add Client** quick action on the [Firm Portal](/docs/firm-portal/) landing or from the **Add Client** button on the Clients grid.
+
+The wizard takes a few minutes per client and runs through six structured sections. The single most important framing point is at the bottom of this page: **onboarding does not create a §32 attestation** — for restricted-segment clients, that is a separate subsequent step.
+
+## Who can onboard a client
+
+Onboarding is gated to **firm Owners only**. The check runs against the firm's `UserBusinessAccess` row for the current user; either `PermissionLevel == "Owner"` or `Role == "Owner"` is sufficient.
+
+Non-Owner staff who navigate to `/firm/clients/onboard` see:
+
+> Only firm owners can onboard new clients.
+
+A separate check runs against the firm's subscription tier. If the firm has reached its maximum-clients limit (25 for Founding Member and Accounting Firm tiers; unlimited for Enterprise), the wizard refuses to proceed and surfaces an upgrade prompt.
+
+## The six sections
+
+The wizard walks through these sections in order. Each section's required fields must be valid before you can advance.
+
+### 1. Business identification
+
+- **Business name** — required; how the client will appear in your firm grid
+- **Trading name** — optional; surfaced on outputs that show DBA / trading style
+- **TIN** — required; 9 digits, **MOD-11 validated** server-side via `OnboardingService.ValidateTINAsync`. An invalid TIN is rejected at this step
+- **Industry category** — required; selects from a controlled list. Some categories (food-related) enable the conditional Food Store License section in step 6.
+
+### 2. VAT configuration
+
+- **VAT number** — required for registered businesses
+- **VAT registration date** — required; cross-field paired with the VAT number (must be a real registration date, not a placeholder)
+- **Annual turnover** — required; the value auto-computes the **filing frequency** via `FilingFrequencyHelper`: turnover ≥ $5M assigns **Monthly** filing, otherwise **Quarterly**. The auto-computed value is shown to you before commit.
+- **Fiscal year end** — required; drives period generation in step 6 of the post-submit flow.
+
+### 3. Contact + Billing contact
+
+- **Primary contact name, email, phone**
+- **Billing contact** — defaults to primary contact; can be set independently
+
+### 4. Address
+
+- **Address line 1**, **Address line 2** (optional)
+- **Island** — selects from the `BahamasIsland` enum (New Providence, Grand Bahama, Abaco, etc.)
+- **PO Box** (optional)
+
+### 5. Engagement
+
+- **Engagement start date**
+- **Engagement type** — `FullService` / `FilingOnly` / `AdvisoryOnly`. This is a firm-internal classification that does not affect Comply's filing behaviour but is surfaced on workload reports
+
+### 6. Food Store Licence (conditional)
+
+This section appears only if the industry category in section 1 was food-related.
+
+- **Licence number**
+- **Expiry date**
+
+The licence is referenced by the VAT rate engine when the client posts transactions: certain reduced-rate categories require an active food-store licence at the transaction date. See [VAT Rates Reference](/docs/reference/vat-rates) for the rate engine's licence-fallback behaviour.
+
+## What happens after submit
+
+When you click **Add Client** at the end of the wizard, `ClientOnboardingService.OnboardClientAsync` runs inside a single EF execution-strategy transaction:
+
+1. A new `Business` row is created with `ManagingOrgId = your firm's id`, `Status = "Active"`, `IsActive = true`. This is what makes the new client appear in your Firm Portal grid via the [firm-to-client access traversal](/docs/firm-portal/firm-client-access).
+2. `UserBusinessAccess` rows are granted to every firm-business owner with `PermissionLevel = "Owner"` and `Role = "Owner"`. This ensures Owner-level staff can immediately work on the new client without separate per-user grants.
+3. The transaction commits.
+4. **After commit**, `FilingPeriodService.GeneratePeriodsForBusinessAsync(yearsAhead: 2)` runs — Comply pre-creates two years of filing periods (monthly or quarterly per the assigned frequency) so the client's filing calendar is populated.
+5. A `BusinessCreated` audit event is written best-effort (try/catch). A ledger-write failure does not roll back the client creation — the persisted business is the source of truth; the ledger entry is the audit-trail evidence.
+
+You return to the Firm Portal landing with the new client visible in the grid.
+
+## What onboarding does NOT do
+
+Two regulatory-clarity points that catch every new firm onboarding a §3 restricted-segment client for the first time:
+
+### Onboarding does NOT create a §32 attestation
+
+The wizard creates the `Business` row and the access grants — that's it. No `Attestation` row is persisted. For a non-restricted-segment client this is sufficient: the per-return [Signatory Capacity Declaration](/docs/vat-returns/filing-wizard#step-4-approval-signatory-capture) at filing time satisfies §32 on its own.
+
+For a **§3 restricted-segment client**, you must subsequently run the §32 Attestation Entry Pathway (Wave 2.2 deliverable — `attestation-entry-pathway`) from the client's record before any return can be lodged. The Firm Portal landing's [`Pending Re-attestations` KPI card](/docs/firm-portal/#the-dashboard-at-a-glance) surfaces this requirement; new clients in restricted segments appear there immediately after onboarding.
+
+### Onboarding does NOT send a client invitation
+
+The wizard creates the client business under your firm's management; it does not send an invitation email to the client's owner or staff to log in to Comply themselves. To grant the client direct access to their own business, use the separate **Invite Client** flow on the Clients grid — see [Client Invitation Lifecycle](/docs/firm-portal/user-management#client-invitation-lifecycle).
+
+## Bulk import — for large client books
+
+For firms migrating an existing book of clients into Comply, the **Bulk Client Import** flow at `/firm/clients/bulk-import` accepts a CSV file with the same fields as the wizard, validated row-by-row before any row commits. The Bulk Client Import surface is the CSV-driven analog to this wizard and runs through the same `ClientOnboardingService` per row.
+
+## Next steps
+
+- [How Firm-to-Client Access Works](/docs/firm-portal/firm-client-access) — why your newly-onboarded client appears in your grid
+- [Firm Portal](/docs/firm-portal/) — landing page + dashboard
+- [User Management](/docs/firm-portal/user-management) — granting access to additional firm staff + client-side invitations
+- [Filing Wizard](/docs/vat-returns/filing-wizard) — what happens at filing time for non-restricted-segment clients

--- a/docs/firm-portal/firm-client-access.md
+++ b/docs/firm-portal/firm-client-access.md
@@ -59,7 +59,7 @@ Your `UserBusinessAccess` row pointing at the firm self-business is revoked. Fro
 
 ### When a firm's clients are reassigned across staff
 
-Per-staff assignment lives on the `ClientAssignment` entity (workload distribution) — a layer above access. You can have firm-portal access to a client (and see it in the grid) without being its currently-assigned practitioner. See [User Management](/docs/firm-portal/user-management) for the workload-assignment surface and §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ for how attestation interacts with reassignment.
+Per-staff assignment lives on the `ClientAssignment` entity (workload distribution) — a layer above access. You can have firm-portal access to a client (and see it in the grid) without being its currently-assigned practitioner. See [User Management](/docs/firm-portal/user-management) for the workload-assignment surface and [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) for how attestation interacts with reassignment.
 
 ## Access vs §32 attestation — different gates
 
@@ -85,6 +85,6 @@ These properties match the project's mandatory rule that every database query fi
 ## Next steps
 
 - [Firm Portal Landing](/docs/firm-portal) — what the resolved client set looks like in the dashboard
-- §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ — the regulatory-authority gate that runs *in addition to* access control
+- [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) — the regulatory-authority gate that runs *in addition to* access control
 - [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation) — runtime enforcement when the §32 gate fires
 - [User Management](/docs/firm-portal/user-management) — how `UserBusinessAccess` rows are created and revoked

--- a/docs/firm-portal/index.mdx
+++ b/docs/firm-portal/index.mdx
@@ -34,14 +34,14 @@ The Firm Portal landing page renders **seven KPI cards** drawing on aggregate da
 |---|---|---|
 | **Total Clients** | Count of active client businesses in your access set | Excludes archived clients |
 | **Pending Filings** | Count of returns in `ReadyToFile` / `AwaitingDirConfirmation` state across clients | Bridges to [Filing Wizard](/docs/vat-returns/filing-wizard) |
-| **Pending Re-attestations** | Count of clients with no active §32 attestation or with a stale attestation (text-drift detected) | **Clickable** — links to the client grid pre-filtered to `?filter=pending-reattestation`. Surfaces the §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ for the firm administrator |
+| **Pending Re-attestations** | Count of clients with no active §32 attestation or with a stale attestation (text-drift detected) | **Clickable** — links to the client grid pre-filtered to `?filter=pending-reattestation`. Surfaces the [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) for the firm administrator |
 | **Compliance Score** | Aggregate firm compliance health with High / Medium / Low / Not-Assessed chips | Computed from per-client compliance scores |
 | **Portfolio Net VAT** | Sum of net VAT due / refundable across the period | Negative if the portfolio is a net refund |
 | **Returns Filed This Quarter** | Count of returns that reached `Lodged` or `Lodged & Paid` in the current quarter | See the [canonical lifecycle](/docs/vat-returns/#return-lifecycle) for state definitions |
 | **Next Deadline** | Countdown to the next filing deadline across your portfolio | Displays an overdue overlay if any return is past its deadline |
 
 :::warning Pending Re-attestations is regulatorily significant
-The `Pending Re-attestations` count is the firm-administrator's view of clients that cannot currently be filed for under the §32 pathway. Clicking it opens the client grid filtered to those clients so each can be routed through the §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_. Treat a non-zero count as actionable work, not a status indicator.
+The `Pending Re-attestations` count is the firm-administrator's view of clients that cannot currently be filed for under the §32 pathway. Clicking it opens the client grid filtered to those clients so each can be routed through the [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway). Treat a non-zero count as actionable work, not a status indicator.
 :::
 
 ## Quick actions
@@ -76,7 +76,7 @@ From the Firm Portal landing, click the **Add Client** quick action (or the Add 
 
 The wizard captures six structured sections (Business Identification, VAT Configuration, Contact + Billing, Address, Engagement, conditional Food Store License). It is gated to **firm Owners only** — non-Owners cannot onboard clients.
 
-See Client Onboarding _(detailed page coming in Wave 2.2)_ for the full capture sequence, the validation rules, and what onboarding does *not* do (specifically: it does not create a §32 attestation; that is a separate step for restricted-segment clients).
+See [Client Onboarding](/docs/firm-portal/client-onboarding) for the full capture sequence, the validation rules, and what onboarding does *not* do (specifically: it does not create a §32 attestation; that is a separate step for restricted-segment clients).
 
 ## Managing permissions
 
@@ -88,7 +88,7 @@ See [User Management](/docs/firm-portal/user-management) for the canonical permi
 
 ## §32 attestation in the Firm Portal
 
-The Firm Portal is the entry point for the firm-administrator side of the §32 attestation lifecycle. The `Pending Re-attestations` KPI card surfaces clients that need attention; clicking through routes you to the §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_, which walks a practitioner through the carve-out qualifying screen and the regulatory acknowledgement modal that ultimately writes the `ATTESTATION_CREATED` audit event.
+The Firm Portal is the entry point for the firm-administrator side of the §32 attestation lifecycle. The `Pending Re-attestations` KPI card surfaces clients that need attention; clicking through routes you to the [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway), which walks a practitioner through the carve-out qualifying screen and the regulatory acknowledgement modal that ultimately writes the `ATTESTATION_CREATED` audit event.
 
 The lifecycle states themselves (Active / Superseded / VoidedByAssignmentChange) and the relationship to the per-return Signatory Capacity Declaration are documented separately at [Section 32 Attestation Overview](/docs/attestation/).
 
@@ -107,8 +107,8 @@ All Firm Portal features are available at no cost during open beta. Subscription
 ## Next steps
 
 - [How Firm-to-Client Access Works](/docs/firm-portal/firm-client-access) — the access model that resolves your client set
-- Client Onboarding _(detailed page coming in Wave 2.2)_ — the 6-section wizard for adding a client
-- §32 Attestation Entry Pathway _(documentation coming in Wave 2.2)_ — what to do for restricted-segment clients
+- [Client Onboarding](/docs/firm-portal/client-onboarding) — the 6-section wizard for adding a client
+- [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) — what to do for restricted-segment clients
 - [Batch Filing](/docs/firm-portal/batch-filing) — file multiple returns in a single workflow
 - [Firm Analytics](/docs/firm-portal/analytics) — cross-client trends and staff productivity
 - [User Management](/docs/firm-portal/user-management) — permissions, granular access, and the client invitation lifecycle

--- a/docs/firm-portal/user-management.md
+++ b/docs/firm-portal/user-management.md
@@ -22,15 +22,19 @@ Summary cards display:
 
 ## Permission Levels
 
-| Level | Description | Access |
-|-------|-------------|--------|
-| **Owner** | Full access to all features | Everything including user management and settings |
-| **Accountant** | Manages data and reports | Transactions, returns, reports, compliance |
-| **User** | View-only access | Read-only access to data and reports |
+Comply recognises two **base permission levels** on `UserBusinessAccess`:
+
+| Level | What it grants | Notes |
+|---|---|---|
+| **Owner** | Full access to the business — settings, user management, every feature surface | At least one Owner must exist at all times (see Last-Owner protection below) |
+| **Accountant** | Default for non-Owner staff — data management within the business | Access is further refined per-category via the granular permission matrix |
+
+There is no separate "View Only" or "Review Only" permission level. A read-only experience is achieved by granting **Accountant** as the base level and turning off the editing permissions in the granular matrix.
 
 ### Granular Permissions
 
-Beyond the base permission level, you can configure granular access per user across:
+Above the base level, an Owner can configure per-category access for any Accountant. The categories are:
+
 - **Transactions** — Create, edit, delete, import
 - **Reports** — View, export, share
 - **Compliance** — View scores, manage alerts
@@ -38,11 +42,33 @@ Beyond the base permission level, you can configure granular access per user acr
 - **User Management** — Add/remove users
 - **Security** — View audit logs, security settings
 
-:::info §32 Attestation Pathway for Complex-Supply Clients
-Assigning a practitioner as the **practitioner of record** on a client (and activating their attestation profile) controls access to BICA prefill for complex-supply returns.
+Each category exposes the operations relevant to it. Toggling Transactions → Create off, for example, gives the Accountant read-and-edit access to transactions without the ability to add new ones.
 
-- **Customer-facing overview:** [coralledger.com/section-32-pathway](https://www.coralledger.com/section-32-pathway)
-- **Operator documentation:** [Section 32 Attestation Pathway](/docs/attestation/) — practitioner-of-record assignment, BICA verification, prefill activation, audit trail.
+:::warning Last-Owner protection
+A business must always have at least one Owner. The user-management surface refuses to demote or remove the **sole** remaining Owner — both actions are blocked with a clear error message. To replace the last Owner, first promote a second user to Owner, then demote the original.
+:::
+
+:::info §32 attestation is independent of permission level
+Permissions and §32 attestations are **two distinct artefacts**. Changing a user's `PermissionLevel` does **not** create, supersede, or void any `Attestation` row.
+
+- An Accountant can hold an `Active` attestation for a client and continue to sign returns under it until the attestation is voided through a separate flow.
+- Revoking a user's Accountant access from a business removes their day-to-day access but does **not** void any attestation they hold on that business. To void the attestation, route through the reassignment flow described below.
+- An Owner does not implicitly hold an attestation — Owner status grants full firm-portal access, not regulatory authority.
+
+See [Section 32 Attestation Overview](/docs/attestation/) for the admin attestation lifecycle and the [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) for the creation flow. The runtime gate that fires when a user no longer holds the regulatory authority is documented at [Practitioner Revocation Gate](/docs/attestation/practitioner-revocation).
+:::
+
+## Reassigning a Client Between Practitioners
+
+When a firm needs to transfer a client from one practitioner to another, the **Reassign Client** flow is the canonical path. It performs two coupled actions:
+
+1. The prior practitioner's `ClientAssignment` row is marked `IsActive = false`; a new `ClientAssignment` is created for the new practitioner.
+2. Every `Active` `Attestation` for the client business is moved to `VoidedByAssignmentChange` status. An `ATTESTATION_VOIDED_BY_ASSIGNMENT_CHANGE` audit-ledger entry is written for each voided row.
+
+The new practitioner must then run the [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) before the client can be filed for again.
+
+:::info Today this flow is API-only
+The Reassign Client flow is available **today** only through the `/api/v1/accounting-firm/reassign-client` endpoint — the corresponding Clients-grid row action in the Comply UI is a placeholder pending implementation (see [Comply #3125](https://github.com/caribdigital/coralledgercomply/issues/3125) for the Phase 2 UI work). Until the UI ships, firms that need to reassign a client should coordinate with Comply support to invoke the API.
 :::
 
 ## Client Invitation Lifecycle

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -140,8 +140,10 @@ const sidebars: SidebarsConfig = {
       items: [
         'firm-portal/index',
         'firm-portal/firm-client-access',
+        'firm-portal/client-onboarding',
         'firm-portal/batch-filing',
         'firm-portal/analytics',
+        'firm-portal/attestation-entry-pathway',
         'firm-portal/user-management',
       ],
     },


### PR DESCRIPTION
## Summary

The TRIGGERS regulatory-content wave of Phase 2 (epic #161). Three sub-issues land together because they share cross-references.

## What lands

### NEW: docs/firm-portal/attestation-entry-pathway.md (#164)

TRIGGERS-class page per Cass scoping criteria. The three-stage firm-side flow:
- Stage 1: Carve-Out Qualifying Screen
- Stage 2: Regulatory Acknowledgement Modal (the only Razor surface writing ATTESTATION_CREATED)
- Stage 3: AttestationService.CreateAttestationAsync semantics

Plus explicit framing of:
- What the pathway does NOT do (Supersede / Void / batch-Void are API-only / background-only today)
- Read-side state discovery separate from state-transition (RE_ATTEST_REQUIRED)
- When the pathway is required (§3 restricted segments) and when it isn't (per-return Signatory Capacity Declaration suffices)

### NEW: docs/firm-portal/client-onboarding.md (#163)

NONE-class page covering the 6-section onboarding wizard with explicit Owner-only gating, subscription-limit interaction, the auto-computed filing frequency rule, post-submit transaction semantics. Most regulatorily significant: the **What onboarding does NOT do** callout (does not create §32 attestation; does not send client invitation) — cross-linking to the entry pathway above.

### REWRITE: docs/firm-portal/user-management.md (#167)

- Permission-levels table corrected to 2 rows (Owner / Accountant); 'User' tier removed
- Last-Owner protection :::warning callout added
- §32 attestation callout replaced with Wave-5-aligned 'two distinct artefacts' framing; PermissionLevel changes do NOT void Attestation
- New 'Reassigning a Client Between Practitioners' section — frames the coupled ClientAssignment + Attestation void as API-only today, with the Clients-grid UI stub tracked under Comply #3125

## Supporting

- sidebars.ts: client-onboarding (3), attestation-entry-pathway (5) inserted in canonical order
- firm-portal/index.mdx + firm-client-access.md: previously deferred cross-links now resolve

## Verification

- Docusaurus build: green
- All forward-references from Wave 2.1 ('documentation coming in Wave 2.2') now resolve to real pages
- No 'View Only' / 'Review Only' as named permission tiers

## Closes

- #163 — Client Onboarding documentation
- #164 — §32 Attestation Entry Pathway documentation
- #167 — User Management drift fixes

## Cass retroactive sign-off requested

The three-stage attestation framing on attestation-entry-pathway.md and the 'permissions are independent of attestation' framing on user-management.md are regulatorily significant and warrant Cass's read.

## Cross-reference

- Phase 2 epic: #161
- Wave 2.1 PR #170 (merged) — landing + traversal that this wave builds on
- Wave 5 PR #155 — the artifact-distinction framing applied here
- Wave 4 PR #154 — practitioner-revocation runtime gate (cross-linked from attestation-entry-pathway)