### PR TITLE
Fix marketing-site link in navbar — apex to www (prod hotfix)

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -112,7 +112,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://coralledger.com',
+          href: 'https://www.coralledger.com',
           label: 'CoralLedger',
           position: 'right',
         },


### PR DESCRIPTION
User-reported prod issue 2026-05-30: the 'CoralLedger' navbar link on the docs site pointed at `https://coralledger.com` (apex) rather than the canonical `https://www.coralledger.com`.

One-line fix in `docusaurus.config.ts:115`. Other coralledger.com references in the codebase are legitimate subdomains (docs / comply / status / cdn / stg-*) and remain unchanged.

No build or test impact.