### PR TITLE
Wave 2.3: Batch Filing drift rewrite -- 4 steps, all-or-nothing, no per-client §61, §32 gap framed (closes #165)

### DIFF
--- a/docs/firm-portal/batch-filing.md
+++ b/docs/firm-portal/batch-filing.md
@@ -1,152 +1,102 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 title: Batch Filing
-description: File VAT returns for multiple clients at once
+description: File VAT returns for multiple clients in a single workflow — the four-step wizard, the all-or-nothing readiness gate, and the regulatorily significant differences from single-client filing
 ---
 
 # Batch Filing
 
-Efficiently file VAT returns for multiple clients in a single workflow.
+Batch Filing lets a firm process VAT returns for many clients in a single coordinated workflow. It is intended for the natural end-of-period flow where dozens of returns share a deadline and per-client validation would be repetitive.
 
-## When to Use Batch Filing
+Before you read the workflow, two regulatory framings matter:
 
-- End of filing period approaching
-- Multiple clients with same deadline
-- Streamlining quarterly filing process
-- Reducing repetitive tasks
+:::warning Batch filing does not capture per-client §61 acknowledgement or per-client signatory capacity
+The [single-client Filing Wizard](/docs/vat-returns/filing-wizard) captures a §61 penalty acknowledgement and a signatory capacity declaration per return. The batch flow uses a **single batch-wide consent checkbox** and does not capture either per-client. For clients in a §3 restricted segment, route them through the single-client Filing Wizard instead so the per-return Signatory Capacity Declaration runs.
+:::
+
+:::warning Batch filing does not verify §32 attestation status today
+The current `BatchFilingValidationService` runs the 10-point pre-flight check per client but does **not** read attestation state. A restricted-segment client with no `Active` §32 attestation can pass the batch readiness gate. Until the §32 check is integrated into batch validation (tracked in a Comply repo follow-up), file restricted-segment clients individually through the [Filing Wizard](/docs/vat-returns/filing-wizard) so the attestation prefill gate runs.
+:::
+
+These framings reflect what the app does today, not what it ought to do. Both warnings will retire when the corresponding Comply implementation work lands.
+
+## When to use Batch Filing
+
+- Many clients share a quarterly or monthly deadline and are all ready (no blocking validation errors).
+- The clients are **not** in §3 restricted segments — i.e. they don't require an active §32 attestation.
+- The clients have been recently validated and you expect the batch to pass cleanly.
+
+For high-stakes returns (restricted-segment, large net VAT exposure, recent compliance issues) prefer the single-client Filing Wizard so the per-return §61 / signatory capture and attestation gates run.
 
 ## Accessing Batch Filing
 
-Navigate to **Firm Portal > Batch Filing** from the main menu.
+Navigate to **Firm Portal → Batch VAT Filing** (the quick action on the landing page) or directly to `/firm/batch-filing`.
 
-## Batch Filing Workflow
+## The four-step wizard
 
-### Step 1: Select Clients
+| Step | Internal id | What you do |
+|---|---|---|
+| **1 — Select Clients** | _selection_ | Pick the clients to include from the eligible-clients grid |
+| **2 — Preview** | FIRM-007 | Review the per-client readiness summary — totals, status, blocking errors / warnings |
+| **3 — Confirm** | FIRM-008 | Tick the batch-wide consent checkbox and submit |
+| **4 — Report** | FIRM-009 | Read the per-client outcome report; download or retry failures |
 
-The batch filing dashboard shows all clients with returns ready for filing:
+### Step 1 — Select Clients
 
-| Column | Description |
-|--------|-------------|
-| **Client** | Business name |
-| **Period** | Filing period (e.g., Q3 2024) |
-| **Status** | Ready, Needs Review, Not Ready |
-| **Net VAT** | Amount payable/refundable |
-| **Validation** | Pass/Warning/Error count |
+The eligible-clients grid lists clients with returns visible for the current period. Use the filter controls (filing period, status, staff assignment, compliance score) to narrow the list. Tick the clients you want in the batch.
 
-**Filter Options:**
-- By filing period
-- By status (Ready only)
-- By staff assignment
-- By compliance score
+The grid surfaces each client's current readiness inline so you can spot problems before progressing.
 
-### Step 2: Review Validation
+### Step 2 — Preview
 
-Before adding to the batch, review each client's validation status:
+For each selected client, Comply runs the same 10-point pre-flight validation that the single-client Filing Wizard runs. Each client gets a **readiness level**:
 
-- **Green checkmark** - All validations passed
-- **Yellow warning** - Review recommended
-- **Red error** - Must resolve before filing
+| ReadinessLevel | Meaning |
+|---|---|
+| **Ready** | All 10 validations pass; the client can be filed in this batch |
+| **Warning** | Validations passed with warnings (e.g. a near-deadline filing); you can choose to proceed |
+| **NotReady** | One or more blocking validations failed; the client cannot be included until resolved |
+| **AlreadyFiled** | A return for this client / period combination has already reached `Lodged` — no action needed |
 
-Click on any client to view detailed validation results.
+You can deselect NotReady or AlreadyFiled clients here.
 
-### Step 3: Create Batch
+### Step 3 — Confirm
 
-1. Select clients using checkboxes
-2. Click **Add to Batch**
-3. Review batch summary
-4. Confirm batch creation
+This step's confirmation checkbox is the **single batch-wide consent**. It is not a per-client §61 acknowledgement and it is not a signatory capacity declaration — both of those artefacts are captured per-return only in the single-client Filing Wizard.
 
-### Step 4: Process Batch
+:::warning All-or-nothing refusal
+**If any selected client has a blocking validation error at submit time, the entire batch is refused.** Comply does not start the batch and silently skip NotReady clients — it stops with a clear error so you can re-triage. Remove NotReady clients from the selection or resolve their blocking errors before retrying.
+:::
 
-The batch processor:
-1. Generates each return
-2. Runs final validation
-3. Prepares filing packages
-4. Creates audit records
+### Step 4 — Report
 
-**Progress Tracking:**
-- Real-time progress bar
-- Per-client status updates
-- Error highlighting
-- Completion notification
+After the batch completes, Comply renders a per-client outcome report:
 
-### Step 5: Review Results
+- **Succeeded** — return was lodged in Comply via the firm's signature; reference numbers (`VAT-YYYYMMDD-XXXXXXXX`) are listed
+- **Failed** — return failed to lodge; the per-client error is shown so you can retry individually
+- **Skipped** — the client was selected but Comply skipped it (rare; typically a race condition)
 
-After processing:
-- View successful filings
-- Address any failures
-- Download filing confirmations
-- Generate batch report
+You can download the batch report and retry individual failures from this surface.
 
-## Batch Queue Management
+## What gets persisted
 
-### Queue Status
+Per-client, the batch flow goes through the same lifecycle as a single-client filing — `Draft → ReadyToFile → FilingInProgress → AwaitingDirConfirmation`. Each client's return moves into `AwaitingDirConfirmation` after batch artifact generation succeeds.
 
-| Status | Meaning |
-|--------|---------|
-| **Pending** | Waiting to process |
-| **Processing** | Currently being filed |
-| **Completed** | Successfully filed |
-| **Failed** | Error occurred |
-| **Cancelled** | Removed from queue |
+To complete the lifecycle to `Lodged`, you must subsequently capture the DIR Acknowledgement per client through the [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) flow on each return — **the batch surface does not record DIR lodgement.** The batch reaches the artefacts-ready point only.
 
-### Managing the Queue
-- Reorder clients in queue
-- Remove clients from batch
-- Pause/resume processing
-- Retry failed filings
+This intentional split keeps the lodgement audit entry (`RETURN_LODGED_WITH_DIR`) accurate per client — each lodgement has its own date, method, reference number, and artefact checksums.
 
-## Compliance Status Aggregation
+## Audit events
 
-View aggregate metrics across your batch:
-
-- Total clients in batch
-- Total net VAT payable
-- Average compliance score
-- Validation pass rate
-
-## Best Practices
-
-### Before Batch Filing
-
-1. **Run validation on all clients** - Catch issues early
-2. **Resolve blocking errors** - Remove clients not ready
-3. **Review warnings** - Address where possible
-4. **Confirm filing periods** - Ensure correct periods selected
-
-### During Batch Filing
-
-1. **Monitor progress** - Watch for failures
-2. **Don't navigate away** - Let batch complete
-3. **Note any issues** - For follow-up
-
-### After Batch Filing
-
-1. **Download confirmations** - Keep records
-2. **Update client files** - Note filing completion
-3. **Address any failures** - Process individually
-4. **Generate batch report** - For internal records
-
-## Scheduling Batch Filing
-
-Set up recurring batch filing schedules:
-
-1. Go to **Settings > Report Scheduling**
-2. Create new schedule
-3. Select "Batch Filing Preparation"
-4. Set frequency and timing
-5. Configure notification preferences
+The batch services themselves do not write batch-level audit events. The per-client filing operations they invoke write the normal single-client audit set (`FILING_INITIATED`, `FILING_ARTIFACTS_GENERATED`). The Audit Trail for each client reflects exactly what happened, whether it was reached via single-client or batch filing.
 
 ## Reporting
 
-Generate reports on batch filing activity:
+The Multi-Client Reports surface (`/firm/reports`) shows batch-filing activity aggregated with single-client filings — there is no separate batch-history surface today. Filter by date range or by client to see what landed in a given window.
 
-- **Batch History** - All batch filing sessions
-- **Client Filing History** - Per-client filing record
-- **Staff Performance** - Filings by team member
-- **Compliance Trends** - Batch compliance over time
+## Next steps
 
-## Next Steps
-
-- [View firm analytics](/docs/firm-portal/analytics)
-- [Manage client settings](/docs/firm-portal)
+- [Filing Wizard](/docs/vat-returns/filing-wizard) — single-client filing where per-client §61 acknowledgement + signatory capture happen
+- [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) — the post-artefacts lodgement capture (per client, not batched)
+- [Firm Analytics](/docs/firm-portal/analytics) — cross-client reporting context
+- [§32 Attestation Entry Pathway](/docs/firm-portal/attestation-entry-pathway) — for restricted-segment clients that the batch flow does not gate


### PR DESCRIPTION
## Summary

Wave 2.3 of Phase 2 (epic #161). Single-page rewrite of `docs/firm-portal/batch-filing.md` per Cass scoping criteria. INDIRECT class — the inline cross-links are the three regulatorily-significant warnings at the top of the page.

## Corrections (false claims removed)

- **5 steps → 4 steps** matching BatchFiling.razor MudStepper (Select / Preview FIRM-007 / Confirm FIRM-008 / Report FIRM-009)
- **Queue Management section removed** — no batch queue exists; runs synchronously
- **Scheduling Batch Filing section removed** — no verified scheduling path in current Comply
- **Reporting section corrected** — surfaces roll into Multi-Client Reports, not a separate batch-history surface

## Regulatory framings added (3 top-of-page warnings)

1. **No per-client §61 acknowledgement / signatory capacity capture** — batch uses a single batch-wide consent checkbox; route restricted-segment clients through single-client Filing Wizard
2. **No §32 attestation check today** — `BatchFilingValidationService` does not read attestation state; tracked as a Comply repo follow-up
3. **All-or-nothing refusal** — if any client has blocking errors, the entire batch is refused (not silently-skip behavior)

## Additional content

- `ReadinessLevel` enum documented (Ready / Warning / NotReady / AlreadyFiled)
- Per-client lifecycle clarification: batch reaches `AwaitingDirConfirmation` only; `Lodged` requires subsequent per-client Record DIR Acknowledgement
- Audit-event clarification: batch services do not write batch-level events; per-client filing audit set fires as normal

## Out of scope — Comply repo follow-up

Batch filing should consult attestation state for restricted-segment clients before allowing them into the readiness pass. Filed as a follow-up against `caribdigital/coralledgercomply` — this docs PR describes what the app does today.

## Verification

- Docusaurus build: green
- All cross-links resolve to existing pages (Wave 2.1/2.2 work, plus Phase 1 filing-wizard / record-dir-ack)

## Cass retroactive sign-off requested

The three top-of-page warnings are regulatorily significant — Cass should read before publication.

## Closes

- #165 — Batch Filing drift

## Cross-reference

- Phase 2 epic: #161
- Code sources: `BatchFiling.razor`, `BatchFilingService.cs`, `BatchFilingValidationService.cs`