### PR TITLE
Wave 3.1: Account-creation trio -- Quick Start + Create Account + 2FA (closes #176, #177, #178)

### DIFF
--- a/docs/getting-started/create-account.mdx
+++ b/docs/getting-started/create-account.mdx
@@ -1,13 +1,12 @@
 ---
 sidebar_position: 2
 title: Create Your Account
-description: Sign up for CoralLedger Comply
+description: Sign up for CoralLedger Comply — the four-step registration wizard
 ---
-
 
 # Create Your Account
 
-Get started with CoralLedger Comply by creating your account.
+Get started with CoralLedger Comply by completing the four-step registration wizard at [comply.coralledger.com/Account/Register](https://comply.coralledger.com/Account/Register).
 
 :::info Free Beta — Open Beta in progress
 CoralLedger Comply is currently in free beta. All features are available at no cost during open beta. Subscription billing begins after open beta.
@@ -26,36 +25,96 @@ Demo recordings of this workflow will be added here. Topics:
 - Business setup
 :::
 
-## Step 1: Visit the Sign-Up Page
+## The four-step wizard
 
-Go to [comply.coralledger.com/Account/Register](https://comply.coralledger.com/Account/Register)
+The registration form is a wizard with four ordered steps. You complete each step before advancing; the form persists what you've entered locally for 24 hours so you can return to a partial submission.
 
-## Step 2: Enter Your Details
+### Step 1: Account Details
 
-- **Email address** — Use your business email
-- **Password** — At least 8 characters with uppercase, lowercase, numbers, and a special character
-- **Full name** — Your name as the account owner
+Capture your personal credentials:
 
-You'll need to complete a CAPTCHA verification to proceed.
+- **First Name** and **Last Name** — separate fields, both required
+- **Email address** — required; checked for availability while you type, so you'll see immediately if the email is already registered
+- **Password** — required; **at least 15 characters** with **uppercase**, **lowercase**, **a number**, and **a special character**
+- **Confirm Password** — must match
+- **Phone Number** — optional
+- **How did you hear about us?** — optional dropdown
 
-## Step 3: Verify Your Email
+A **Cloudflare Turnstile** invisible widget runs in the background to confirm you are not a bot. There is no per-page CAPTCHA challenge unless Turnstile asks for one.
 
-Check your inbox for a verification email and click the confirmation link. You cannot log in until your email is verified.
+### Step 2: Account Type
 
-:::tip Check Your Spam Folder
-If you don't see the verification email within a few minutes, check your spam or junk folder.
+Choose what kind of account you are setting up:
+
+| Account type | Who picks this |
+|---|---|
+| **New Business** | A single business owner registering their own business |
+| **Join Existing** | A user joining an existing business via an invitation code |
+| **Accounting Firm** | A firm administrator registering an accounting firm — this also creates the firm self-business and assigns the FirmOwner Identity role |
+
+Your choice routes you through the next step's fields. See [Set Up Your Business](/docs/getting-started/setup-business) for the full description of each account type.
+
+### Step 3: Business Information
+
+The fields shown here depend on your Step 2 selection:
+
+**For New Business and Accounting Firm:**
+
+- **Business Name** — required
+- **TIN** — required, 9 digits, MOD-11 validated server-side
+- **VAT Number** — optional during registration; can be added later
+- **Industry** — required, selects from a controlled list of 15 categories
+- **Estimated Annual Turnover** — required, selects from 5 ranges. The chosen range auto-computes your **filing frequency** (Monthly for $5M+, Quarterly otherwise).
+
+If your industry is food-related, an additional **food-store qualification block** appears:
+
+- **Do you sell unprepared food?**
+- **Do you hold a pharmacy licence?**
+- **What percentage of your turnover is food-related?**
+
+These three answers determine whether your business qualifies for the 5% Reduced rate on breadbasket items, and whether the food-store fallback rules apply (see [VAT Rates Reference](/docs/reference/vat-rates) for the rate engine's behaviour).
+
+**For Accounting Firm only:** add
+
+- **Billing Contact Email**
+- **Expected Client Count**
+
+**For Join Existing:** the only field is
+
+- **Invitation Code**
+
+### Step 4: Email Verification
+
+After Step 3 submits, you receive an email from Comply containing both:
+
+- A **6-digit verification code** valid for 15 minutes
+- A **clickable link** that completes registration on the originating tab
+
+Enter the code on the registration screen or click the link from your email. Either path completes the same flow. **Until you complete verification, your user account does not exist** — there is no separate "log in but not yet verified" state in Comply.
+
+Also on this step:
+
+- Tick the **Accepted Terms** checkbox
+- The registration is finalised; you are auto-signed-in and redirected to your dashboard
+
+:::tip Check your spam folder
+If you don't see the verification email within a few minutes, check your spam or junk folder. Email arrives from CoralLedger's address.
 :::
 
-## Step 4: Complete Business Setup
+## After verification
 
-After email verification, you'll configure your business:
-- **New Business** — Enter your business name, TIN, and details
-- **Join Existing** — Enter an invitation code if joining an existing firm
+You arrive at the appropriate landing page based on your account type:
 
-## Subscription Tiers (Subscription billing begins after open beta)
+- **New Business** users land at the [Client Dashboard](/docs/getting-started/dashboard-tour) (`/client`).
+- **Accounting Firm** users land at the [Firm Portal](/docs/firm-portal/) (`/firm/portal`).
+- **Join Existing** users land at the business they were invited to.
+
+If your account somehow ends up without a business context (rare — usually only if an invitation chain breaks), you are routed to a recovery setup page — see [Set Up Your Business](/docs/getting-started/setup-business).
+
+## Subscription tiers
 
 | Tier | Founder Price | Standard Price | Clients |
-|------|---------------|----------------|---------|
+|---|---|---|---|
 | **Single Business** | $49/mo | $99/mo | 1 business |
 | **Accounting Firm** | $99/mo | $499/mo | Up to 25 clients |
 | **Enterprise** | Custom | Custom | Unlimited |
@@ -66,7 +125,9 @@ Founder pricing is locked for life for early adopters. Single Business founders 
 
 During open beta, all features are available at no cost regardless of tier.
 
-## Next Steps
+## Next steps
 
-- [Set up your business](/docs/getting-started/setup-business)
+- [Set up your business](/docs/getting-started/setup-business) — the three account types and the recovery flow
+- [Enable Two-Factor Authentication](/docs/security/two-factor-auth) — strongly recommended for all users
+- [Tour the dashboard](/docs/getting-started/dashboard-tour) — what you see after first login
 - [Learn about the Founders Circle](/docs/billing/founders-circle)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -24,12 +24,12 @@ CoralLedger Comply is a VAT compliance platform built specifically for businesse
 
 ## Getting Started in 5 Minutes
 
-1. **Create your account** — Sign up at [comply.coralledger.com](https://comply.coralledger.com) with email verification and CAPTCHA
-2. **Set up 2FA** — Two-factor authentication is required on first login for security
-3. **Set up your business** — Enter your TIN (9 digits) and business details
-4. **Import transactions** — Upload your CSV or enter transactions manually
-5. **Review categorization** — Verify VAT categories are correct
-6. **Generate your return** — Create your VAT return with the DIR form format
+1. **Create your account** — Sign up at [comply.coralledger.com](https://comply.coralledger.com). The 4-step wizard walks you through account details, account type, business info, and email verification — see [Create Your Account](/docs/getting-started/create-account).
+2. **Set up your business** — During registration you choose between a single business, joining an existing one with an invitation code, or registering an accounting firm. See [Set Up Your Business](/docs/getting-started/setup-business).
+3. **(Recommended) Enable Two-Factor Authentication** — 2FA is strongly recommended but only enforced for PlatformAdmin users. Set it up from your account settings — see [Two-Factor Authentication](/docs/security/two-factor-auth).
+4. **Import transactions** — Upload your CSV or enter transactions manually.
+5. **Review categorization** — Verify VAT categories are correct.
+6. **Generate your return** — Create your VAT return with the DIR form format.
 
 ## Key Features
 

--- a/docs/security/two-factor-auth.md
+++ b/docs/security/two-factor-auth.md
@@ -1,16 +1,24 @@
 ---
 sidebar_position: 2
 title: Two-Factor Authentication
-description: Set up and manage 2FA for your CoralLedger Comply account
+description: Set up and manage 2FA for your CoralLedger Comply account — recommended for all users, enforced for PlatformAdmin
 ---
 
 # Two-Factor Authentication (2FA)
 
-Two-factor authentication adds an extra layer of security by requiring a verification code from your phone in addition to your password.
+Two-factor authentication adds an extra layer of security to your account by requiring a verification code from your phone in addition to your password.
 
-## Why 2FA is Required
+## When 2FA is required vs recommended
 
-CoralLedger Comply stores and processes sensitive financial data including VAT returns, transaction records, and business information. 2FA is mandatory for all users to protect this data.
+Comply applies 2FA differently depending on role:
+
+| User type | 2FA status |
+|---|---|
+| **PlatformAdmin** (Ops Portal access) | **Enforced** — every session must complete the 2FA challenge or it is rejected with `403 Forbidden` |
+| **Admin / Administrator** | **Recommended** — a dismissable banner is shown on the dashboard prompting setup; access is not blocked |
+| **All other users** (Owner, Accountant, individual business users) | **Recommended** — no banner is shown, but the option is always available in account settings |
+
+The strong recommendation is that every user enables 2FA — Comply stores and processes sensitive financial data including VAT returns, transaction records, and business information. But day-to-day app access is not gated on a 2FA challenge for ordinary users today.
 
 ### 2FA for the Ops Portal (PlatformAdmin)
 
@@ -24,25 +32,31 @@ PlatformAdmin accounts without 2FA configured cannot access the Ops Portal. If y
 
 ## Setting Up 2FA
 
-### First-Time Setup
+### How to enable
 
-When you first log in, you'll be prompted to set up 2FA:
+Navigate to `/Account/TwoFactorSetup` (or open your profile menu and choose **Two-Factor Authentication**). The setup page walks you through:
 
-1. Download an authenticator app on your phone
-2. Scan the QR code displayed on screen
-3. Enter the 6-digit verification code from your app
-4. Save your backup codes in a secure location
+1. Download an authenticator app on your phone — see Supported Authenticator Apps below.
+2. Scan the QR code shown on screen with the app, or enter the manual secret key if you cannot scan.
+3. Enter the 6-digit verification code that the authenticator app generates to confirm pairing.
+4. Save your backup codes (see Backup Codes below) in a secure location before continuing.
+
+After setup, the next time you log in you will be asked for a 6-digit code in addition to your password.
 
 ### Supported Authenticator Apps
+
+Comply supports **TOTP** (Time-based One-Time Passwords) only. Any TOTP-compatible authenticator app works. Apps Comply explicitly tests against:
 
 - **Google Authenticator** (Android / iOS)
 - **Microsoft Authenticator** (Android / iOS)
 - **Authy** (Android / iOS / Desktop)
 - **1Password** (Android / iOS / Desktop)
 
-Any TOTP-compatible authenticator app will work.
+SMS-based or hardware-token 2FA is not supported.
 
 ## Logging In with 2FA
+
+If you have 2FA enabled:
 
 1. Enter your email and password as usual
 2. When prompted, open your authenticator app
@@ -55,28 +69,40 @@ Codes refresh every 30 seconds. If your code is about to expire, wait for the ne
 
 ## Backup Codes
 
-During 2FA setup, you receive a set of one-time backup codes. These are for emergency access if you lose your phone.
+During 2FA setup, Comply generates **10 single-use backup codes** in the format `XXXX-XXXX`. These are for emergency access if you lose your phone.
 
 **Important:**
+
 - Each backup code can only be used once
 - Store them securely (password manager, printed copy in a safe)
-- If you run out of backup codes, contact support
+- The setup page offers a one-click download of the codes as a text file — save it somewhere you can find later
+- If you run out of backup codes, you can regenerate a fresh set from the 2FA settings (this invalidates the prior set)
+- If you lose access to all backup codes AND your authenticator, contact support
 
 ## Managing 2FA
 
 ### Resetting 2FA
-If you need to switch authenticator apps:
-1. Go to **Settings > Account**
-2. Find the **Security** section
-3. Follow the prompts to reset and reconfigure 2FA
+
+To switch authenticator apps (e.g. moving from Google Authenticator to 1Password):
+
+1. Go to **Account Settings** → **Two-Factor Authentication**
+2. Choose **Reset 2FA**
+3. Re-enter your password to confirm
+4. Step through the setup flow again with the new authenticator
+
+### Disabling 2FA
+
+You can disable 2FA from the same settings panel. Doing so requires re-entering your password. The backup codes are invalidated when you disable.
 
 ### Lost Access
-If you've lost both your phone and backup codes:
+
+If you've lost both your phone and your backup codes:
+
 1. Contact privacy@digitalcarib.com
-2. You'll need to verify your identity
+2. You'll need to verify your identity through an out-of-band channel
 3. An administrator can reset your 2FA
 
 ## Next Steps
 
-- [Review login history](/docs/settings/account)
-- [Manage security settings](/docs/security)
+- [Account settings](/docs/settings/account) — manage your profile, password, and 2FA configuration
+- [Security overview](/docs/security/) — broader security posture (IP blocking, fraud alerts, role-based access)


### PR DESCRIPTION
## Summary

Wave 3.1 of Phase 3 (epic #175). Lands the account-creation trio — Quick Start guide, Create Account page, and Two-Factor Authentication page — together because they cross-link extensively and share the same regulatory framing (2FA is recommended, not mandatory for ordinary users; PlatformAdmin enforcement is the only hard gate).

## Changes

### `docs/getting-started/index.md` (closes #176)
- Line 28 "2FA required on first login" — **false claim** replaced with honest "recommended but only enforced for PlatformAdmin"
- 5-Minute Quick Start re-sequenced: Create → Set Up Business → (Recommended) Enable 2FA → Import → Review → Generate

### `docs/getting-started/create-account.mdx` (closes #177) — full rewrite
- **4-step wizard** documented: Account Details → Account Type → Business Info → Email Verification (was: 4 generic sub-headings as if linear)
- **Password policy corrected**: at least 15 characters (was: at least 8)
- **Cloudflare Turnstile** named (was: generic "CAPTCHA")
- **FirstName + LastName** as separate required fields (was: "Full name")
- **Account Type selector** documented with 3 options (was: omitted entirely)
- **Step 3 Business Info** documented including the **food-store qualification block** (was: omitted entirely)
- **Step 4 Verification** correctly framed — both 6-digit code AND link; account doesn't exist until verification completes
- After-verification routing documented per account type

### `docs/security/two-factor-auth.md` (closes #178) — full rewrite
- **Top-of-page table** distinguishing PlatformAdmin (enforced) vs Admin (recommended via banner) vs ordinary users (recommended, no banner)
- "2FA is mandatory for all users" — **false claim** replaced
- "First-Time Setup" framing reworked — no longer implies mandatory first-login flow
- **Backup codes spec** documented: 10 codes, format `XXXX-XXXX`, single-use, downloadable, regeneratable
- **Setup path corrected**: `/Account/TwoFactorSetup` (was: "Settings > Account > Security")
- PlatformAdmin enforcement section preserved (was accurate)

## Verification

- Docusaurus build: green
- Resurrection guards:
  - "2FA is mandatory" / "required on first login" — 0 hits in user-facing copy
  - "at least 8 characters" — 0 hits in registration-policy context
  - "CAPTCHA" alone (with Turnstile being a more accurate framing) — kept generic where readable
- Cross-links resolve

## Cass retroactive sign-off requested

The 2FA "recommended for users / enforced for PlatformAdmin" framing is security-policy adjacent — Cass should review for regulatory accuracy.

## Closes

- #176 — Quick Start 2FA-mandatory false claim
- #177 — Create Account 4-step + password + Turnstile + food-store block
- #178 — 2FA documentation honest framing

## Cross-reference

- Phase 3 epic: #175
- Code: `Register.razor`, `BusinessFirstRegistrationService.cs`, `TwoFactorSetup.razor`, `TwoFactorAuthService.cs`, `Dashboard.razor:34` (admin-only gate)
