### PR TITLE
Wave 3.2: Set Up Business + Dashboard Tour rewrites (closes #179, #180)

### DIFF
--- a/docs/getting-started/dashboard-tour.md
+++ b/docs/getting-started/dashboard-tour.md
@@ -1,64 +1,133 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Dashboard Tour
-description: Navigate the CoralLedger Comply dashboard
+description: Where /dashboard routes you, what the Client Dashboard renders, and how to navigate the app
 ---
 
 # Dashboard Tour
 
-Learn your way around the CoralLedger Comply dashboard.
+When you log in to CoralLedger Comply you land at `/dashboard`. This page is a **router** — it inspects your account context and redirects you to the actual dashboard for your role:
 
-## Dashboard Types
+| Your context | You land at |
+|---|---|
+| Single business (self-filing) or client view | **Client Dashboard** at `/client` |
+| Accounting firm without a self-filing business | **Firm Portal** at `/firm/portal` — see [Firm Portal](/docs/firm-portal/) |
+| No business context | Setup-required page at `/Account/BusinessSetupRequired` — see [Set Up Your Business](/docs/getting-started/setup-business) |
 
-After logging in, you're directed to the appropriate dashboard based on your account type:
-- **Client Dashboard** — For individual businesses (self-filing)
-- **Firm Portal** — For accounting firms managing multiple clients
+This page covers the **Client Dashboard** (`/client`) — the canonical landing for individual business users.
 
-## Client Dashboard
+## The Client Dashboard
 
-The client dashboard provides a real-time overview of your VAT compliance:
+The Client Dashboard is a live overview of your current period's VAT position, your compliance health, and the actions most likely to be useful next. The page updates in real time over a SignalR connection to `/dashboardHub`, so changes (transaction imports, compliance score moves, alerts) reflect without you needing to refresh.
 
-### Summary Cards
-- **Compliance Score** — Your A+ to F grade with trend indicator
-- **Next Filing Deadline** — Countdown to your next return due date
-- **Net VAT Position** — Current period's VAT payable or refundable
-- **Recent Activity** — Latest transactions and actions
+The page renders the following components, in this order:
 
-### Quick Actions
-- Import transactions
-- Enter a new transaction
-- Generate VAT return
-- View compliance alerts
+### 1. Compliance Weather
 
-### Widgets
-- **Filing Deadline Calendar** — Visual timeline of upcoming deadlines
-- **Transaction Summary** — Period totals by VAT category
-- **Compliance Alerts** — Active warnings and recommendations
+A large card at the top of the page showing your overall **compliance score** as a letter grade (A+ through F) with a weather-style metaphor — sunny for a clean A, cloudy for compliance issues to attend to, stormy for blocking problems. The grade rolls up data-quality, timeliness, accuracy, and completeness signals.
+
+### 2. Tide Timer
+
+A countdown to your **next filing deadline**, prominently displayed. The deadline accounts for your filing frequency (Monthly or Quarterly) plus the 21-day standard (or 14-day Large Taxpayer) window per the VAT Act.
+
+### 3. Compliance Alert Bar
+
+A horizontal bar showing **status / deadline / Net VAT Payable** at a glance. Click through any of the three for the underlying detail surface.
+
+### 4. Quick Actions
+
+Four large action cards for the most common next steps:
+
+| Action | Goes to | When to use |
+|---|---|---|
+| **Import Data** | CSV import / connectors | Bringing in transactions for the period |
+| **Review** | Data Quality surface | Reviewing categorisation suggestions, fixing issues |
+| **Prepare Return** | VAT Returns | Generating the return for the current period |
+| **Pay** | Payment surface | Recording payment back into Comply after lodgement |
+
+These are the same four named actions the app renders — not generic "Import / Enter / Generate / Alerts".
+
+### 5. VAT Summary Metric Card
+
+A compact card with the period's headline figures: **Sales**, **VAT Out**, **Purchases**, **VAT In**, **Net Due**. Updates live as transactions are imported.
+
+### 6. Network Graph (VAT-Flow Visualisation)
+
+A larger card (1000×400) showing the flow of VAT for the current period as a network diagram — sales contributing to Output VAT, purchases contributing to Input VAT, the net position. Useful for spotting outliers visually.
+
+### 7. Current Period Summary + Data Health
+
+Two paired smaller cards:
+
+- **Current Period Summary** — totals by VAT category (Standard / Reduced / Zero-Rated / Exempt)
+- **Data Health Indicator** — share of transactions with complete metadata vs flagged ones
+
+### 8. Conditional: Tax Recovery + Bad Debt Relief
+
+If your business has activity that qualifies for tax-recovery treatment or bad-debt-relief adjustments under the VAT Act, additional cards appear here. They are conditional — businesses without qualifying activity won't see them.
+
+See [Bad Debt Relief](/docs/compliance/bad-debt-relief) for the bad-debt-relief workflow.
+
+### 9. Recent Activity Feed
+
+A vertical feed of recent actions on the business — transactions imported, categories applied, returns generated, settings changes. Time-ordered, newest first.
+
+### 10. Recent Transactions
+
+A table at the bottom of the dashboard showing the most recent 6 transactions with their ID, Date, Type, Amount, VAT, and Status. Click any row to open the transaction.
+
+## Real-time updates
+
+The dashboard maintains a SignalR connection to `/dashboardHub`. Updates pushed to the connection include:
+
+- Compliance score recalculations after categorisation changes
+- New transactions imported by team members
+- Status changes on returns (e.g. Awaiting Lodgement → Lodged)
+- Compliance alerts firing or clearing
+
+You don't need to refresh — these surface live as they happen.
 
 ## Navigation
 
-### Sidebar Menu
-- **Dashboard** — Overview and metrics
-- **Transactions** — View, enter, and manage transactions
-- **Import** — Upload CSV transaction data
-- **VAT Returns** — Generate, view, and submit returns
-- **Credit Notes** — Manage credit notes and adjustments
-- **Compliance** — Intelligence dashboard, anomaly detection, and scoring
-- **Reports** — Cash flow, variance analysis, custom reports, audit trail
-- **Firm Portal** — Multi-client management (firm accounts only)
-- **Settings** — Account, business, appearance, integrations
-- **Help** — In-app help center and guides
+### Sidebar menu
 
-### Top Bar
-- **Business Switcher** — Switch between client businesses (for multi-client users)
-- **Notifications** — Bell icon with unread count
-- **Account Menu** — Profile, settings, logout
+Your sidebar typically includes:
+
+- **Dashboard** — the router that brought you here
+- **Transactions** — view, enter, and manage transactions
+- **VAT Returns** — generate, view, and submit returns
+- **Compliance** — intelligence dashboard, anomaly detection, scoring
+- **Reports** — cash flow, variance analysis, custom reports
+- **Firm Portal** — multi-client management (firm accounts only)
+- **Audit Trail** — immutable history of activity
+- **Settings** — account, business, appearance, integrations
+- **Help** — in-app help links
+
+What you see varies with your role and granular permissions.
+
+### Top bar
+
+- **Business Switcher** — switch between client businesses (visible if you have access to multiple)
+- **Notifications** — bell icon with unread count
+- **Account Menu** — profile, settings, logout
 
 ### Business Switcher
-If you manage multiple businesses, click the business name in the top bar to switch context. All data displayed will update to reflect the selected business.
 
-## Next Steps
+If you manage multiple businesses (e.g. you are a firm staff member with access to several clients), click the business name in the top bar to switch context. Every dashboard, list, and report below the top bar reflects the selected business.
 
-- [Import your transactions](/docs/transactions/import-csv)
+For the firm-administrator view of the same access model, see [How Firm-to-Client Access Works](/docs/firm-portal/firm-client-access).
+
+## What you see after first login depends on your account type
+
+| Account type | Lands at |
+|---|---|
+| New Business | Client Dashboard (`/client`) — described on this page |
+| Accounting Firm | Firm Portal (`/firm/portal`) — see [Firm Portal](/docs/firm-portal/) |
+| Join Existing | Whichever dashboard is canonical for the business you joined |
+
+## Next steps
+
+- [Import your transactions](/docs/transactions/import-csv) — feed the dashboard with data
 - [Understand VAT categories](/docs/transactions/categorization)
-- [View compliance score](/docs/compliance/compliance-score)
+- [View your compliance score](/docs/compliance/compliance-score)
+- [Firm Portal](/docs/firm-portal/) — if you are an accounting firm

--- a/docs/getting-started/setup-business.md
+++ b/docs/getting-started/setup-business.md
@@ -1,58 +1,119 @@
 ---
 sidebar_position: 3
 title: Set Up Your Business
-description: Configure your business profile in CoralLedger Comply
+description: The three account types in CoralLedger Comply and the two surfaces where business setup happens
 ---
 
 # Set Up Your Business
 
-Configure your business profile to start managing VAT compliance.
+Comply captures business information on two distinct surfaces, depending on where you are in the lifecycle:
 
-## Account Type
+- **During registration** — Step 3 of the [4-step registration wizard](/docs/getting-started/create-account#step-3-business-information) is where most users capture their business details. It's a rich form covering industry, turnover, and (where applicable) the food-store qualification block.
+- **Recovering when no business is associated** — if your account is somehow left without a business context (rare — usually only after an invitation chain breaks), Comply routes you to a thin recovery page at `/account/business-setup` that captures the minimum needed to get you back to a working dashboard.
 
-When setting up, choose your account type:
-- **New Business** — Create a new business profile from scratch
-- **Join Existing** — Enter an invitation code to join an existing firm or business
+This page covers both surfaces and the three account types you can choose between.
 
-## Required Information (New Business)
+## The three account types
 
-- **Business Name** — Your registered business name
-- **TIN** — Tax Identification Number (9 digits, no "V" prefix)
-- **VAT Number** — Your VAT registration number (optional during setup)
+When you register, you pick **one of three account types**. Your choice determines what fields are captured next and where you land after verification.
 
-## Optional Settings
+| Account type | Who picks this | What gets created |
+|---|---|---|
+| **New Business** | A single business owner registering their own business | A `Business` row with you as Owner via `UserBusinessAccess` |
+| **Join Existing** | A user joining an existing business via an invitation code | A `UserBusinessAccess` row connecting you to the existing `Business` — no new business is created |
+| **Accounting Firm** | A firm administrator registering a new accounting firm | A firm **self-business** (the house account that represents the firm itself), plus the `FirmOwner` Identity role on your account, plus `UserBusinessAccess` to the firm self-business |
 
-After initial setup, you can configure additional details at **Settings > Business**:
+The three flows route through `BusinessFirstRegistrationService` in code, with the AccountingFirm path additionally calling `CreateAccountingFirmAsync` to provision the firm self-business and assign the `FirmOwner` role.
 
-- **Trading Name** — Name you operate under (if different from registered name)
-- **Business Address** — Physical location in The Bahamas
-- **Industry** — Helps with transaction categorization
-- **Food Store License** — Required for 5% reduced rate eligibility on breadbasket items
-- **Logo** — Upload for branded VAT invoices and reports
-- **Filing Frequency** — Monthly or quarterly filing periods
-- **Large Taxpayer** — Designation for businesses meeting the Large Taxpayer threshold
+## During registration (Step 3)
 
-## TIN Format
+This is the canonical place to capture business details. The fields you see depend on your account type:
 
-Your TIN should be entered as 9 digits without dashes or prefixes. The system will format it as `###-###-###` for display.
+### New Business or Accounting Firm
 
-:::info VAT Threshold
-Businesses with taxable supplies over $100,000 BSD annually must register for VAT with the Department of Inland Revenue.
+- **Business Name** — required; appears as your business name across the app
+- **TIN** — required; 9 digits, no `V` prefix, no dashes. MOD-11 validated server-side
+- **VAT Number** — optional during registration; can be added later from **Settings > Business**
+- **Industry** — required, 15 categories. Drives some categorisation defaults later
+- **Estimated Annual Turnover** — required, 5 ranges. Auto-computes your filing frequency (**Monthly** for $5M+ annual turnover, **Quarterly** otherwise)
+
+**If your industry is food-related**, an additional food-store qualification block appears:
+
+- **Do you sell unprepared food?**
+- **Do you hold a pharmacy licence?**
+- **What percentage of your turnover is food-related?**
+
+These answers determine whether your business qualifies for the **5% Reduced rate** on hygiene / medical / breadbasket items at licensed food stores, and whether the rate-fallback rules apply (see [VAT Rates Reference](/docs/reference/vat-rates) for the engine behaviour).
+
+### Accounting Firm — additional fields
+
+For the AccountingFirm account type, two firm-level fields are also captured:
+
+- **Billing Contact Email** — where invoices will be sent once billing begins (after open beta)
+- **Expected Client Count** — used to scope the appropriate subscription tier
+
+The firm self-business uses the same Business Name + TIN + VAT Number as your firm's own registration.
+
+### Join Existing — single field
+
+For the JoinExisting account type, the only field is:
+
+- **Invitation Code** — generated by the existing business owner or firm administrator when they sent the invitation. Valid for 7 days from issue.
+
+If the code is valid, your account links to that business when verification completes. See the [Client Invitation Lifecycle](/docs/firm-portal/user-management#client-invitation-lifecycle) on the firm side for how invitations are issued.
+
+## Recovery — when no business is associated
+
+If you log in and your account does not have a current business context, Comply routes you to `/account/business-setup`. This happens rarely — usually when:
+
+- An invitation you accepted later got revoked
+- A business you were Owner of was deleted while you were not signed in
+- You signed up in a way that bypassed Step 3 of registration
+
+The recovery page is intentionally thin compared to Step 3 of registration. You choose between:
+
+- **Create New Business** — captures only **Business Name**, **TIN**, and **VAT Number** (optional). Industry, turnover, and food-store qualifications can be filled in later under **Settings > Business**.
+- **Join Existing** — captures only the **Invitation Code**.
+
+After submission, you arrive at the appropriate dashboard for the resolved business.
+
+## Optional settings (fill in later)
+
+Whether you set up during registration or via recovery, additional business details can always be filled in later from **Settings > Business**:
+
+- **Trading Name** — display name if different from registered business name
+- **Business Address** — Bahamian island + address lines + PO Box
+- **Logo** — upload for branded VAT invoices and reports
+- **Filing Frequency** — Monthly or Quarterly (auto-set from turnover during registration; editable here)
+- **Large Taxpayer designation** — for businesses meeting the threshold, see [VAT Rates Reference](/docs/reference/vat-rates) and [Filing and Payment Deadlines](/docs/statutes/filing-payment-deadlines)
+- **Food Store Licence** number and expiry — required for the 5% Reduced rate fallback rules
+
+## TIN format
+
+Your TIN is entered as **9 digits** without dashes or prefixes. The system formats it as `###-###-###` for display.
+
+:::info VAT registration threshold
+Businesses with taxable supplies over **$100,000 BSD annually** must register for VAT with the Department of Inland Revenue. See [Registration Obligation and Threshold](/docs/statutes/registration-obligation-threshold) for the statutory reference.
+
+If you are not yet registered, you can still create a Comply account and use the platform to track transactions. When your VAT number is issued, add it under **Settings > Business**.
 :::
 
-## VAT Registration
+## VAT registration
 
-If you're not yet registered:
-1. Apply at the Department of Inland Revenue
-2. Receive your VAT number
-3. Enter it in CoralLedger Comply at **Settings > Business**
+If you do not yet have a VAT number:
+
+1. Apply at the Department of Inland Revenue.
+2. Receive your VAT number.
+3. Enter it in CoralLedger Comply at **Settings > Business**.
 
 ## By Statute References
 
 - [Registration Obligation and Threshold](/docs/statutes/registration-obligation-threshold)
 
-## Next Steps
+## Next steps
 
-- [Tour the dashboard](/docs/getting-started/dashboard-tour)
+- [Create your account](/docs/getting-started/create-account) — the 4-step registration wizard
+- [Tour the dashboard](/docs/getting-started/dashboard-tour) — what you see after first login
+- [Firm Portal — Client Onboarding](/docs/firm-portal/client-onboarding) — how firms add their own clients (distinct from this page)
 - [Import your first transactions](/docs/transactions/import-csv)
 - [Enter transactions manually](/docs/transactions/manual-entry)


### PR DESCRIPTION
## Summary

Wave 3.2 of Phase 3 (epic #175). Two related rewrites — both flow from the same NewBusiness / JoinExisting / AccountingFirm account-type model.

## Set Up Your Business — full rewrite (closes #179)

- **Two surfaces distinguished**: Step 3 of registration (rich) vs `/account/business-setup` recovery (thin)
- **All three account types** documented (was: 2 — AccountingFirm omitted entirely)
- Per-type field lists with **AccountingFirm-specific** Billing Contact Email + Expected Client Count + firm-self-business + FirmOwner role
- **Food-store qualification block** documented (was: omitted)
- Filing-frequency auto-compute rule ($5M+ → Monthly) named
- Optional-later fields section preserved

## Dashboard Tour — full rewrite (closes #180)

- `/dashboard` documented as a **router page** with all three redirect targets
- **All 10+ ClientDashboard components** named in render order (was: 4 generic cards)
- **4 specific Quick Action cards** named: Import Data / Review / Prepare Return / Pay (was: generic 4)
- **SignalR live-update** behaviour via `/dashboardHub` documented for the first time
- Sidebar + business-switcher cross-linked to Phase 2 firm-client-access

## Verification

- Docusaurus build: green
- All cross-links resolve

## Closes

- #179 — Setup Business (three account types + dual-surface clarification)
- #180 — Dashboard Tour rewrite

## Cross-reference

- Phase 3 epic: #175
- Wave 3.1 PR #182 (merged) — Create Account, Quick Start, 2FA
- Phase 2 firm-client-access — cross-linked from business-switcher section
- Code: `Register.razor`, `BusinessSetup.razor`, `BusinessFirstRegistrationService.cs`, `Dashboard.razor`, `ClientDashboard.razor`
