### PR TITLE
Wave 3.3: Mobile + Performance + Settings>Account accuracy rewrites (closes #181)

### DIFF
--- a/docs/getting-started/mobile.mdx
+++ b/docs/getting-started/mobile.mdx
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 5
 title: Mobile Experience
-description: Use CoralLedger Comply on mobile devices
+description: Using CoralLedger Comply from a phone or tablet — responsive web in any modern browser
 ---
 
 # Mobile Experience
 
-CoralLedger Comply is fully responsive and optimized for mobile devices, so you can manage VAT compliance from anywhere.
+CoralLedger Comply is a **responsive web application** — it adapts its layout to phones, tablets, and desktops without needing a separate mobile app. There is no App Store / Play Store install; you access the platform from your device's browser the same way you would on a laptop.
 
 ## Mobile Walkthrough
 
@@ -16,40 +16,49 @@ A demo recording of the responsive interface on phone and tablet will be added h
 
 ## Supported Devices
 
-- **Smartphones** — iOS and Android browsers
-- **Tablets** — iPad, Android tablets
+- **Smartphones** — iOS Safari and Android Chrome
+- **Tablets** — iPad Safari, Android tablet browsers
 - **Desktop** — All modern browsers
 
-No app installation required — access CoralLedger Comply directly from your device's browser.
+The mobile experience uses the same URL as desktop: [comply.coralledger.com](https://comply.coralledger.com). No app installation is required.
 
-## Mobile-Optimised Features
+## What works well on mobile
+
+Comply's layout reflows for narrow screens. The components you use most on mobile are designed for one-handed phone use:
 
 ### Dashboard
-The compliance dashboard adapts to smaller screens, displaying your compliance score, upcoming deadlines, and action items in a single-column layout.
+
+The Client Dashboard's KPI cards stack into a single column on a phone, with the Compliance Weather card at the top and the Recent Transactions table at the bottom. Tide Timer + Quick Actions remain prominent in the visible viewport on most phones. See [Dashboard Tour](/docs/getting-started/dashboard-tour) for the full component layout.
 
 ### Transaction Entry
-Quickly enter transactions from your phone immediately after a sale or purchase:
-1. Open [comply.coralledger.com](https://comply.coralledger.com)
-2. Navigate to **VAT Entry**
-3. Use Quick Entry mode for fast single-transaction input
+
+Quick Entry mode in VAT Entry was designed for phone input — single-line, large tap targets, minimal field set. Useful for capturing a transaction immediately after a sale or purchase while still on-site. See [Manual VAT Entry](/docs/transactions/manual-entry).
 
 ### VAT Return Review
-Review and approve draft VAT returns from your mobile device before your accountant files.
 
-### Notifications
-Receive browser-based notifications for:
-- Upcoming filing deadlines
-- Compliance score changes
-- Fraud alerts requiring review
+Review and approve a draft VAT return from your phone before forwarding to your accountant for final filing. The return summary and validation states render cleanly on small screens.
+
+## What does NOT work on mobile
+
+Worth knowing what is *not* in scope so you set the right expectations:
+
+- **No PWA install / no service worker / no manifest.** Comply is not a Progressive Web App — you cannot install it as a standalone app icon with background push notifications. Browser-only.
+- **No background notifications.** Filing deadline reminders, compliance alerts, and other notifications appear as in-tab toast messages when you are actively using Comply. They do not push to your device when the tab is closed.
+- **Offline use is not supported.** Comply needs a network connection. There is no local cache that lets you work disconnected.
+- **CSV import via the mobile browser is impractical for large files.** For multi-thousand-row imports use a desktop browser.
 
 ## Tips for Mobile Use
 
-- **Bookmark the app** — Add comply.coralledger.com to your home screen for quick access
-- **Use Quick Entry** — The simplified entry mode is ideal for mobile input
-- **Enable notifications** — Stay informed of deadlines without opening the app
+- **Bookmark in your browser** — add `comply.coralledger.com` to your phone's home screen via your browser's "Add to Home Screen" option. This creates a browser shortcut, not an installed app — it opens in your browser when tapped.
+- **Use Quick Entry mode** — designed for fast one-handed phone input. Find it on the VAT Entry page.
+- **Use the phone for review, the desktop for bulk work** — phone is great for spotting one-off transactions while on-site or reviewing alerts at a glance; desktop is the right surface for CSV import, batch filing, multi-client work, and report generation.
 
-## Next Steps
+## Browser support
 
-- [Create your account](/docs/getting-started/create-account)
-- [Enter transactions manually](/docs/transactions/manual-entry)
-- [Tour the dashboard](/docs/getting-started/dashboard-tour)
+The same browser requirements as desktop apply on mobile — see the [Performance](/docs/getting-started/performance) page for the supported browser versions.
+
+## Next steps
+
+- [Create your account](/docs/getting-started/create-account) — the registration wizard works on mobile but desktop is recommended for first-time setup
+- [Tour the dashboard](/docs/getting-started/dashboard-tour) — what the desktop layout looks like
+- [Enter transactions manually](/docs/transactions/manual-entry) — the Quick Entry path designed for phone use

--- a/docs/getting-started/performance.mdx
+++ b/docs/getting-started/performance.mdx
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 6
 title: Performance
-description: CoralLedger Comply performance and reliability
+description: How CoralLedger Comply is built for responsive interactivity, large data handling, and reliable real-time updates
 ---
 
 # Performance
 
-CoralLedger Comply is built for speed and reliability, ensuring your compliance workflows are never slowed down by the platform.
+CoralLedger Comply is built on a server-rendered Blazor architecture that prioritises responsiveness on Caribbean network conditions. This page documents the actual performance properties of the platform rather than aspirational targets.
 
 ## Performance Walkthrough
 
@@ -14,47 +14,73 @@ CoralLedger Comply is built for speed and reliability, ensuring your compliance 
 A demo recording of fast load times and the responsive UI will be added here.
 :::
 
-## Performance Highlights
+## How the platform is built
 
-### Fast Load Times
-- Sub-second page loads for all core workflows
-- Optimized API responses for transaction lists and reports
-- Lazy loading for large data sets
+Comply runs as a Blazor Server application — UI rendering happens on the server, with the browser maintaining a SignalR connection over which DOM updates flow. This architecture has specific performance properties:
 
-### Large Data Handling
-The platform is designed to support high transaction volumes without degradation:
-- Import CSV files with thousands of transactions
-- Generate returns across full fiscal years
-- Search and filter large transaction histories in real time
+- **Initial page renders are server-side**, so the browser does not need to download a large JavaScript bundle on first load.
+- **Subsequent navigation reuses the SignalR connection**, so page transitions are fast and feel app-like.
+- **Real-time dashboard updates** push from the server when underlying data changes (e.g. new transaction imported, return state changed) without you needing to refresh.
 
-### Reliable Uptime
-- 99.9% uptime target
-- Redundant infrastructure
-- Failover for critical services
+This is the same architectural pattern as products like Microsoft Teams or GitHub Codespaces — interactive web with server-rendered UI.
 
-### Real-Time Updates
-- Compliance score recalculates instantly after transaction changes
-- Dashboard metrics update without page refresh
-- Fraud alerts delivered in real time
+## What this means for you
+
+### Responsive interactivity
+
+Dashboards and lists update without a full-page reload. Filtering a transaction grid, switching businesses, or recalculating a return preview happens in place via the SignalR channel.
+
+### Large data handling
+
+Comply is designed to handle large transaction volumes per business without paginating you out of your data:
+
+- **CSV imports** of thousands of transactions in a single file. The import progress is streamed back over SignalR so you see the row-by-row progress live.
+- **Returns** that cover full fiscal years for businesses with high transaction volumes.
+- **Server-side filtering and sorting** of transaction histories so the browser does not need to hold the full dataset in memory.
+
+### Real-time updates
+
+The Client Dashboard maintains a SignalR connection to `/dashboardHub`. Updates pushed across this connection include:
+
+- Compliance score recalculations after categorisation changes
+- New transactions imported by team members
+- Status changes on returns (e.g. Awaiting Lodgement → Lodged)
+- Compliance alerts firing or clearing
+
+You see these reflect on the dashboard without refreshing.
+
+## Caribbean network reality
+
+The platform is tested against the network conditions a typical Bahamian business will experience — including 3G mobile connections and bandwidth-limited periods. Specific accommodations:
+
+- **Skeleton placeholders** show during data loads so the page feels responsive even when the underlying query is slow.
+- **Per-page data loading** runs in `OnAfterRenderAsync` so the initial render is not blocked by long-running queries.
+- **SignalR retry + reconnect** is built in — if the connection drops, the browser reconnects when the network comes back.
 
 ## Supported Browsers
 
 | Browser | Minimum Version |
-|---------|-----------------|
+|---|---|
 | Chrome | 90+ |
 | Firefox | 88+ |
 | Safari | 14+ |
 | Edge | 90+ |
 
-## Reporting Performance Issues
+Older browsers may render the platform but interactive features (SignalR live updates, modal dialogs, MudBlazor components) may not work correctly.
+
+## Reporting performance issues
 
 If you experience slow performance:
-1. Clear your browser cache and reload
+
+1. Clear your browser cache and reload the page
 2. Check your internet connection speed
-3. Contact support at [privacy@digitalcarib.com](mailto:privacy@digitalcarib.com) with details of the slowness
+3. If the issue persists, contact [privacy@digitalcarib.com](mailto:privacy@digitalcarib.com) with:
+   - The page URL where slowness occurs
+   - The action you were taking when slowness started
+   - Your browser + version (and approximate connection speed if known)
 
-## Next Steps
+## Next steps
 
-- [Quick Start Guide](/docs/getting-started)
+- [Quick Start Guide](/docs/getting-started/)
 - [Import transactions from CSV](/docs/transactions/import-csv)
 - [Generate a VAT return](/docs/vat-returns/generate-return)

--- a/docs/settings/account.md
+++ b/docs/settings/account.md
@@ -1,145 +1,85 @@
 ---
 sidebar_position: 2
 title: Account Settings
-description: Manage your profile, security, and preferences
+description: Manage your profile, password, two-factor authentication, and notification preferences
 ---
 
 # Account Settings
 
-Manage your personal account settings, security options, and preferences.
+Manage your personal account settings, security options, and preferences. Account-level settings are distinct from **business settings** (the per-business configuration on Settings > Business); this page covers what's tied to your individual user account.
 
-## Accessing Account Settings
+## Profile information
 
-Navigate to **Settings > Account** or click your profile icon and select **Account Settings**.
+Update your basic profile from the Profile Settings page:
 
-## Profile Information
+- **Full Name** — your display name (combination of First Name + Last Name as captured at registration)
+- **Email Address** — the verified email used to sign in
+- **Phone Number** — for account recovery (optional)
+- **Profile Picture** — optional; surfaces in the top navigation, team-member lists, and activity logs
 
-### Update Your Profile
-- **Full Name** - Your display name
-- **Email Address** - Login email (verified)
-- **Phone Number** - For account recovery
-- **Timezone** - For accurate deadline displays
+Changes to your name and profile picture are visible immediately to anyone who shares a business with you.
 
-### Profile Picture
-Upload a profile photo that appears:
-- In the top navigation
-- On team member lists
-- In activity logs
+## Change your password
 
-## Security Settings
+The Change Password page lives at `/account/change-password` (or `/change-password`).
 
-### Change Password
+1. Enter your **current password**
+2. Enter and confirm your **new password**
+3. Click **Update Password**
 
-1. Go to **Settings > Change Password**
-2. Enter your current password
-3. Enter and confirm your new password
-4. Click **Update Password**
+**Password requirements** (same policy as registration):
 
-**Password Requirements:**
-- Minimum 8 characters
-- At least one uppercase letter
-- At least one number
-- At least one special character
+- **Minimum 15 characters**
+- At least one **uppercase** letter
+- At least one **lowercase** letter
+- At least one **number**
+- At least one **special character**
 
-### Two-Factor Authentication (2FA)
+If your administrator has flagged your account for required password rotation, the Change Password page surfaces a warning alert prompting you to update before continuing.
 
-Add an extra layer of security to your account.
+## Two-Factor Authentication
 
-**Enable 2FA:**
-1. Go to **Settings > Account**
-2. Find the Security section
-3. Click **Enable 2FA**
-4. Scan the QR code with your authenticator app
-5. Enter the verification code
-6. Save your backup codes securely
+CoralLedger Comply supports TOTP-based 2FA via standard authenticator apps. Setup, recovery, and the backup-code spec are documented separately at [Two-Factor Authentication](/docs/security/two-factor-auth) — that page covers when 2FA is enforced (PlatformAdmin only), when it's recommended (everyone else), and how to set it up.
 
-**Supported Apps:**
-- Google Authenticator
-- Microsoft Authenticator
-- Authy
-- 1Password
+## Notification preferences
 
-:::tip Backup Codes
-Save your backup codes in a secure location. You'll need them if you lose access to your authenticator app.
+Configure how and when CoralLedger Comply contacts you. The Notification Preferences page lets you toggle:
+
+- **Email notifications** for filing deadline reminders, compliance score changes, anomaly detection alerts, weekly summaries, and security alerts
+- **In-app notifications** — toast messages that appear when you are actively using Comply
+
+You access the preferences from your account menu. Quiet hours, per-category fine-grained controls, and channel preferences depend on Comply's notification infrastructure — see the in-app Notification Preferences page for the current options.
+
+## What is NOT on this page
+
+Worth knowing what's out of scope here so you set the right expectations:
+
+- **Active session management** (viewing logged-in devices, revoking sessions) is **not** currently a self-service surface in Comply. If you suspect your account is signed in somewhere you don't recognise, change your password — that invalidates all existing sessions — and contact support if the concern persists.
+- **Detailed login history** (timestamps, IPs, device fingerprints) is captured in the audit ledger but is not surfaced as a user-facing log on this page. Contact support if you need a copy of your login history for a specific period.
+- **Quiet hours** for notifications are not configurable on a per-user basis today. Notifications are sent according to the underlying event triggers; out-of-hours suppression is not yet available.
+
+## Privacy and data handling
+
+CoralLedger Comply handles personal data in line with the Bahamian Data Protection (Privacy of Personal Information) Act 2003. The Privacy contact for data-subject-rights requests is `privacy@digitalcarib.com` — also the address surfaced in the footer on every page.
+
+## Account deactivation and deletion
+
+### Deactivate account
+
+A temporarily deactivated account preserves your data and lets you reactivate later. Active subscriptions continue to bill if applicable. Contact support to deactivate.
+
+### Delete account
+
+Permanent account deletion removes your personal profile data. **Business data is retained for 7 years** per the [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/) — regulatory record-keeping obligations apply even after a user deletes their account. The retained data is no longer associated with your personal identity but remains in the audit ledger.
+
+Contact support to initiate account deletion.
+
+:::warning Data retention is a regulatory obligation
+Even after personal-account deletion, transaction data your business produced is retained for **7 years** under the VAT Act. This is not configurable — the retention period is set by statute.
 :::
 
-### Session Management
+## Next steps
 
-View and manage active sessions:
-- See all logged-in devices
-- View login locations
-- Revoke suspicious sessions
-
-### Login History
-
-Review your recent login activity:
-- Login timestamps
-- IP addresses
-- Device information
-- Success/failure status
-
-Access at **Account > Login History**.
-
-## Notification Preferences
-
-Control how and when you receive notifications.
-
-### Email Notifications
-
-Configure email alerts for:
-- Filing deadline reminders
-- Compliance score changes
-- Anomaly detection alerts
-- Weekly summary reports
-- Security alerts
-
-### In-App Notifications
-
-Toggle dashboard notifications for:
-- New transactions synced
-- Categorization suggestions
-- System updates
-- Team activity (for Firm users)
-
-### Quiet Hours
-
-Set times when non-urgent notifications are silenced:
-- **Start Time** - When quiet hours begin
-- **End Time** - When quiet hours end
-- **Days** - Which days to apply
-
-Access at **Settings > Notifications**.
-
-## Privacy Settings
-
-Control your privacy preferences:
-- Data sharing with analytics
-- Activity visibility to team members
-- Marketing communications
-
-Access at **Settings > Privacy**.
-
-## Danger Zone
-
-### Deactivate Account
-
-Temporarily deactivate your account:
-- Your data is preserved
-- You can reactivate anytime
-- Active subscriptions may continue
-
-### Delete Account
-
-Permanently delete your account:
-- All personal data is removed
-- Business data may be retained for compliance (7 years)
-- This action cannot be undone
-
-:::warning Data Retention
-Due to [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/) requirements, transaction data must be retained for 7 years even after account deletion.
-:::
-
-## Next Steps
-
-- [Configure business settings](/docs/settings)
-- [Set up notifications](/docs/settings/notifications)
+- [Two-Factor Authentication](/docs/security/two-factor-auth) — set up or manage 2FA
+- [Configure business settings](/docs/settings/) — per-business configuration distinct from this page
+- [Security overview](/docs/security/) — broader security posture


### PR DESCRIPTION
## Summary

Wave 3.3 of Phase 3 (epic #175). Three smaller drift rewrites bundled together — Mobile + Performance + Settings > Account.

## docs/getting-started/mobile.mdx — accuracy rewrite

- **Not a PWA** — explicit framing. No service worker, no manifest, no background push.
- **No background notifications** — only in-tab toasts when actively using Comply
- **No offline support** — needs network
- "Bookmark the app" → reframed as **browser shortcut**, not PWA install
- Kept the legitimate responsive-web-supports-mobile content

## docs/getting-started/performance.mdx — rewrite to verified claims

- **Removed:** "Sub-second page loads" (aspirational, no SLO in code)
- **Removed:** "99.9% uptime target" (unverified)
- **Removed:** "Redundant infrastructure / Failover for critical services" (marketing copy)
- **Added:** honest architecture description — Blazor Server + SignalR `/dashboardHub`, server-side rendering, OnAfterRenderAsync data-loading pattern
- **Added:** Caribbean network reality framing (skeleton placeholders, SignalR retry, per-page data load)
- Browser support table kept; reporting workflow tightened

## docs/settings/account.md — accuracy rewrite

- **Password policy corrected**: 15 chars (was: 8) — verified against `ChangePassword.razor:389` `MinimumLength = 15`
- **Change Password route**: `/account/change-password` (or `/change-password`) documented
- **2FA section** trimmed; cross-link to canonical Two-Factor Authentication page from Wave 3.1
- **What is NOT on this page** section added:
  - Active session management — not a self-service surface today (no `ActiveSession` UI in code)
  - Detailed login history — captured in audit ledger but not user-facing
  - Quiet hours — not configurable per-user today
- Privacy section added with the `privacy@digitalcarib.com` data-subject-rights contact (consistent with Phase 1 brand canonicals)
- Account deactivation / deletion framing kept; 7-year retention regulatory framing preserved

## Verification

- Docusaurus build: green
- All claims fact-checked against `ChangePassword.razor`, `Program.cs` (Blazor Server only), `ProfileSettings.razor`, `NotificationPreferences.razor`
- 0 grep hits in src/ for "ActiveSession" / "SessionManagement" / "QuietHours" — confirms those features don't exist
- Resurrection guards: no "8 characters" password claim left; no "99.9% uptime" claim left; no "PWA install" claim left

## Closes

- #181 — Mobile + Performance + Settings > Account accuracy pass

## Cross-reference

- Phase 3 epic: #175
- Wave 3.1 PR #182 (merged) — 2FA framing referenced from Settings > Account
- Code: `ChangePassword.razor`, `Program.cs`, `ProfileSettings.razor`, `NotificationPreferences.razor`
