### PR TITLE
Wave 4.1: Reports + Audit Trail accuracy edits (closes #186, #187)

### DIFF
--- a/docs/audit/audit-reports.md
+++ b/docs/audit/audit-reports.md
@@ -10,7 +10,11 @@ Access detailed audit reports to review all system activity, verify data integri
 
 ## Accessing Audit Reports
 
-Navigate to **Reports > Audit Logs**. Some features require 2FA to be enabled.
+The page lives at `/reports/audit` (also reachable as `/reports/audit-logs`). Navigate via **Reports > Audit Logs** in the sidebar. Some features require 2FA to be enabled.
+
+:::note "Audit Reports" and "Audit Logs" are the same page
+This page IS the audit-log viewer. "Reports" framing reflects the page's read-and-export capability — there is no separate report-generator surface for audit data. The filtered Export button on this page is the only audit-export path.
+:::
 
 ## Dashboard Overview
 
@@ -25,7 +29,7 @@ The audit reports page displays summary cards:
 ### By Event Type
 Filter by specific categories such as:
 - Transaction events
-- Return filing events
+- Return filing events (note: the newer VAT Returns lifecycle events — `FILING_INITIATED`, `RETURN_LODGED_WITH_DIR`, `RETURN_LODGEMENT_RETRACTED`, `PAYMENT_RECORDED`, etc. — are emitted today but the dropdown's hard-coded category list does not yet include them; use "All Events" to see them. Tracked as a Comply repo follow-up.)
 - User authentication events
 - Settings changes
 - Security events

--- a/docs/audit/cross-tenant-audit-viewer.md
+++ b/docs/audit/cross-tenant-audit-viewer.md
@@ -31,8 +31,8 @@ The viewer uses server-side pagination for large cross-tenant result sets. Page 
 
 ## Accessing the Viewer
 
-1. Log in with platform operator credentials
-2. Navigate to **Platform > Audit Viewer**
+1. Log in with platform operator credentials (PlatformAdmin role + completed 2FA challenge — both gates enforced by the `RequirePlatformAdmin` policy)
+2. Navigate to the **Ops Portal → Audit** entry, or directly to `/ops/audit`
 3. The `PLATFORM_OPS_AUDIT_VIEWED` event is logged when the viewer is opened
 
 ## Filtering

--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -21,8 +21,8 @@ CoralLedger Comply maintains an immutable audit trail of all data modifications,
 ### Immutable Hash-Chain
 Each audit entry includes a cryptographic hash of the previous entry, creating an unbreakable chain. Any attempt to modify or delete entries breaks the chain and is immediately detectable.
 
-### WORM Compliance
-Write Once Read Many (WORM) compliance ensures that audit entries cannot be modified or deleted after creation. This meets regulatory requirements for tamper-proof record keeping.
+### Append-only at the application layer
+The `ImmutableAuditEntry` table is treated as append-only by application code — no `UPDATE` or `DELETE` operation runs against it from the service layer. Combined with the hash chain (above), modifications are detectable. Database-level Write-Once-Read-Many enforcement depends on operator configuration (PostgreSQL row-level security and operator privilege separation) and is not a guarantee from the application alone.
 
 ### 7-Year Retention
 All audit data is retained for a minimum of 7 years, in compliance with [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/).
@@ -35,7 +35,8 @@ Administrators can verify the integrity of the entire audit chain at any time, d
 | Event Category | Examples |
 |----------------|----------|
 | **Transactions** | Created, modified, deleted, imported |
-| **VAT Returns** | Generated, submitted, amended |
+| **VAT Returns lifecycle** | `FILING_INITIATED`, `FILING_ARTIFACTS_GENERATED`, `RETURN_APPROVED_BY_SIGNATORY`, `ACK_SECTION61`, `RETURN_LODGED_WITH_DIR` (with artifact checksums), `RETURN_LODGEMENT_RETRACTED`, `PAYMENT_RECORDED`, `NO_PAYMENT_DUE` — see [VAT Returns lifecycle](/docs/vat-returns/) |
+| **§32 Attestation lifecycle** | `ATTESTATION_CREATED`, `ATTESTATION_SUPERSEDED`, `ATTESTATION_VOIDED_BY_ASSIGNMENT_CHANGE`, `ATTESTATION_RE_ATTEST_REQUIRED`, `ATTESTATION_MODAL_CANCELLED` — see [§32 Attestation Overview](/docs/attestation/) |
 | **User Actions** | Login, logout, password change, 2FA events |
 | **Settings Changes** | Business profile updates, permission changes |
 | **Security Events** | Failed logins, IP blocks, fraud alerts |
@@ -43,6 +44,10 @@ Administrators can verify the integrity of the entire audit chain at any time, d
 | **Platform Ops** | Operator dashboard access, user/tenant/business management, impersonation, data deletion, cross-tenant scope |
 
 See [Platform Ops Event Types](/docs/audit/platform-ops-events) for a full reference of all `PLATFORM_OPS_*` events.
+
+:::warning Filter dropdown does not yet expose the lodgement events
+The per-business audit viewer's event-type filter dropdown is hard-coded today and does not include the VAT Returns lifecycle events (`FILING_INITIATED`, `RETURN_LODGED_WITH_DIR`, etc.). The events are still written to the ledger and appear under the "All Events" filter — they just cannot be filtered for explicitly. Tracked as a Comply repo follow-up.
+:::
 
 ## Audit Entry Details
 
@@ -57,7 +62,9 @@ Each audit entry records:
 
 ## Accessing the Audit Trail
 
-Navigate to **Reports > Audit Logs** to view the audit trail.
+The per-business audit log lives at `/reports/audit` (also reachable as `/reports/audit-logs` — both routes bind the same page). Navigate via **Reports > Audit Logs** in the sidebar.
+
+The page exposes filters by event type, actor, entity type, start/end date; a server-paginated grid; chain-integrity verification; and a filtered export (see [Audit Reports](/docs/audit/audit-reports)). For platform operators, the [Cross-Tenant Audit Viewer](/docs/audit/cross-tenant-audit-viewer) at `/ops/audit` provides a unified cross-business view.
 
 ## Cross-Tenant Audit Viewer
 

--- a/docs/reports/scheduled-reports.md
+++ b/docs/reports/scheduled-reports.md
@@ -137,6 +137,10 @@ Scheduled Reports with the **Shared Link** delivery method use the same share-li
 - Schedule history is retained for **90 days**
 - VAT Summary schedules always use the **previous month** period regardless of the period setting
 
+:::note Schedule events vs immutable audit ledger
+Schedule lifecycle events (create, edit, pause, resume, delete, execute) and per-run history are recorded today in the **schedule's own history** surface, separate from Comply's [immutable audit ledger](/docs/audit/). The two surfaces are tracked together as a Comply repo follow-up so that recurring-report activity is traceable from the same audit trail as filings and lodgements.
+:::
+
 ## Next Steps
 
 - [Shared reports](/docs/reports/shared-reports)

--- a/docs/reports/shared-reports.mdx
+++ b/docs/reports/shared-reports.mdx
@@ -47,7 +47,11 @@ Recipients who open a shared link see:
 - Links that exceed their download limit become unavailable
 - Expired links show an "Access Denied" message
 - Invalid or tampered tokens are rejected
-- All downloads are tracked and counted
+- All downloads are tracked and counted via a per-share access log (date, IP, downloaded-file-size)
+
+:::note Access log vs immutable audit ledger
+Share-link access events (creation, download, password failure, revoke) are recorded today in a **dedicated per-share access log**, separate from Comply's [immutable audit ledger](/docs/audit/). The two surfaces are tracked together as a Comply repo follow-up so that external distribution of reports is traceable from the same audit trail as filings and lodgements. Until the follow-up lands, treat the per-share access log on the Shared Reports management surface as the source of truth for download tracking.
+:::
 
 ## Use Cases
 

--- a/docs/reports/variance-analysis.md
+++ b/docs/reports/variance-analysis.md
@@ -1,12 +1,14 @@
 ---
 sidebar_position: 4
-title: Variance Analysis
-description: Analyze import vs. sales variances for VAT compliance
+title: Customs Import Variance Analysis
+description: Compare C7 customs import data against sales revenue for margin checks and VAT Box 14 reconciliation
 ---
 
-# Variance Analysis
+# Customs Import Variance Analysis
 
-The variance analysis report compares C7 customs import data against sales revenue to identify discrepancies, calculate margins, and flag potential compliance issues.
+The variance analysis report is **specifically a customs-import-vs-sales reconciliation tool**. It compares C7 customs import data against sales revenue to identify discrepancies, calculate gross margins, and flag potential compliance issues — including reconciling **VAT Return Box 14 (import VAT)** against actual C7 entries for the period.
+
+This report is **not** a generic VAT period-over-period variance tool. If you need broader period comparison, see the [Custom Report Builder](/docs/reports/custom-reports) (which includes a `PeriodComparison` report type).
 
 ## Accessing the Report
 


### PR DESCRIPTION
## Summary

Targeted accuracy edits across 6 pages (3 Audit Trail + 3 Reports). The existing baseline content was largely correct; these edits address the specific drift the Phase 4 audit surfaced.

## Highlights

- **docs/audit/index.md** — "What Gets Logged" table extended with Phase 1 VAT Returns lifecycle + §32 Attestation lifecycle events. WORM claim replaced with honest "append-only at application layer" framing. Filter-dropdown gap noted as Comply repo follow-up.
- **docs/audit/audit-reports.md** — actual route documented (`/reports/audit`); 'Audit Reports = Audit Logs' clarification; filter-dropdown gap inline.
- **docs/audit/cross-tenant-audit-viewer.md** — actual route documented (`/ops/audit`); RequirePlatformAdmin policy mention.
- **docs/reports/variance-analysis.md** — title sharpened to 'Customs Import Variance Analysis'; "not a generic VAT variance tool" framing.
- **docs/reports/shared-reports.mdx** — per-share access log noted; audit-ledger gap documented honestly.
- **docs/reports/scheduled-reports.md** — schedule history vs audit-ledger gap documented honestly.

## Comply repo follow-ups flagged

- AuditReports.razor event-type dropdown extension (add Phase 1 lodgement events)
- ReportSharingService audit-ledger writes (REPORT_SHARED / REPORT_DOWNLOADED / REPORT_REVOKED)
- ReportSchedulingService audit-ledger writes (SCHEDULE_CREATED / SCHEDULE_EXECUTED / SCHEDULE_DELETED)

## Verification

- Docusaurus build: green
- All cross-links resolve

## Closes

- #186 — Reports section rewrite
- #187 — Audit Trail rewrite

## Cross-reference

- Phase 4 epic: #185
- Cass retroactive sign-off requested for the regulatory-content changes