### PR TITLE
Wave 4.2: Security + Data Ops accuracy edits (closes #188, #189)

### DIFF
--- a/docs/data-ops/data-export.md
+++ b/docs/data-ops/data-export.md
@@ -1,97 +1,81 @@
 ---
 sidebar_position: 5
 title: Business Data Export
-description: Export a complete JSON snapshot of business data in CoralLedger Comply
+description: Export business data as CSV / Excel / JSON / XML through the tenant Admin surface; the cross-tenant Ops export is service-only today
 ---
 
 # Business Data Export
 
-Operators can export a complete snapshot of all data belonging to a business as a structured JSON file. This is useful for regulatory submissions, legal discovery, off-platform archiving, and migrations.
+CoralLedger Comply exposes business data export through two paths today, with different scopes and constraints.
 
-## Accessing Business Data Export
+## Tenant Admin export — the shipped UI
 
-Navigate to **Platform Ops > Data Operations > Export**. This feature requires PlatformAdmin access.
+The tenant Admin Data Export surface lets an Administrator export the business's own data in several formats. It is the canonical user-facing export path.
 
-## What Is Included in the Export
+### Accessing the export
 
-A full business data export contains:
+Navigate to **Admin > Data Export** (route: `/admin/data-export`). This surface requires Administrator access with 2FA enabled. The current business context applies — exports are scoped to the business you are signed into.
 
-| Data Category | Contents |
-|---------------|---------|
-| **Transactions** | All transaction records including amounts, categories, VAT, and attachments metadata |
-| **VAT Returns** | All generated and submitted returns with line-item detail |
-| **Compliance Scores** | Historical compliance score snapshots for the business |
-| **Import Batches** | Records of all CSV and bulk import operations |
-| **Privacy Settings** | The business's data privacy configuration and consent records |
+### Supported export categories
 
-:::info
-File attachments (binary content) are not included in the JSON export. The export contains attachment metadata — file name, type, size, and storage reference. Contact support if you require raw file exports.
+| Category | Format(s) |
+|---|---|
+| **Transactions** | CSV, JSON |
+| **VAT Returns** | Excel |
+| **Compliance Report** | (formatted output) |
+| **VAT XML** | DIR-accepted XML for OTAS submission |
+| **Anomaly Report** | (formatted output) |
+
+Each export is generated synchronously — when you click **Export**, the file is generated and offered for download immediately. There is no separate queue or job-status surface.
+
+### What scoping applies
+
+Exports run server-side and are strictly scoped to the current `BusinessId` (enforced via `IBusinessContextService`). Without a business context, the surface throws `UnauthorizedAccessException` — there is no tenant-Admin path to export another business's data.
+
+## Ops Portal full-business JSON export — service only today
+
+For cross-tenant export use cases (regulatory submissions, legal discovery, off-platform archiving), CoralLedger exposes the `IPlatformDataOpsService.ExportBusinessDataAsync` service method. It returns a complete JSON snapshot of a business's data including transactions, VAT returns, compliance scores, import batches, and privacy settings.
+
+:::warning No Ops Portal UI today
+A dedicated `/ops/data/export` Razor page is **not yet implemented**. The service method exists and is invoked programmatically by Comply support; an Ops Portal user-facing export page is planned but not built. If you need a cross-tenant export, raise it with the support team.
 :::
 
-## Running an Export
+When the service is invoked, it emits a `PLATFORM_OPS_DATA_DELETION_EXPORT` audit event capturing the requesting operator and the target business.
 
-1. Navigate to **Platform Ops > Data Operations > Export**
-2. Select the target business from the dropdown
-3. Optionally filter by date range to limit the export scope
-4. Click **Export Business Data**
-5. The system queues the export job; a progress indicator is displayed
-6. When complete, click **Download** to save the JSON file
+## What an Ops JSON export contains (when produced)
 
-For large businesses, export generation may take several minutes. You will receive an in-app notification and an email when the export is ready.
+The cross-tenant JSON export contains:
 
-## Export File Format
+| Data category | Contents |
+|---|---|
+| **Transactions** | All transaction records including amounts, categories, VAT, and attachment metadata |
+| **VAT Returns** | All generated, lodged, and amended returns with line-item detail |
+| **Compliance Scores** | Historical compliance score snapshots |
+| **Import Batches** | Records of all CSV and bulk import operations |
+| **Privacy Settings** | The business's privacy configuration and consent records |
 
-The export is delivered as a single `.json` file named:
+:::info File attachments not included
+File attachments (binary content) are not included in the JSON export. The export contains attachment metadata — file name, type, size, and storage reference. Contact support if you need raw file exports.
+:::
 
-```
-coralledger-export-{businessId}-{YYYY-MM-DD}.json
-```
+## Security considerations
 
-The top-level structure is:
+- Tenant Admin exports run synchronously and require Administrator + 2FA; the file is delivered to the requesting operator's browser session and is not stored on the platform.
+- Ops Portal service-method exports return bytes to the requesting service; persistence is the support team's responsibility once the export is produced.
+- The `PLATFORM_OPS_DATA_DELETION_EXPORT` audit event traces every Ops-driven export.
 
-```json
-{
-  "exportedAt": "2025-08-15T10:30:00Z",
-  "exportedBy": "operator@example.com",
-  "transactions": [ ... ],
-  "vatReturns": [ ... ],
-  "complianceScores": [ ... ],
-  "importBatches": [ ... ],
-  "privacySettings": { ... }
-}
-```
+## Use cases
 
-## Export History
+| Scenario | Path |
+|---|---|
+| **Regulatory submission to DIR** | Tenant Admin export — VAT XML or PDF artefacts of returns are usually the right surface |
+| **Legal discovery** | Coordinate with support; the Ops service-method export is the route until the UI ships |
+| **Business migration** | Tenant Admin transactions export (CSV/JSON) is usually sufficient for re-import elsewhere |
+| **Data subject request (DSAR)** | Ops service-method export is the right surface; support produces the JSON and delivers it through an authenticated channel |
 
-Each export is recorded in the Export History table with:
-
-- **Export ID** — Unique identifier
-- **Business** — Name of the exported business
-- **Requested By** — Operator who triggered the export
-- **Requested At** — Date and time of the request
-- **Status** — Queued, Processing, Complete, or Failed
-- **Download** — Link to download the completed export
-
-## Security Considerations
-
-- Exports are generated server-side and stored in access-controlled storage
-- Only the requesting operator can download the export file
-- Each export download is recorded in the [Audit Trail](/docs/audit)
-- Exports should be stored securely and in compliance with your data handling obligations
-
-## Use Cases
-
-| Scenario | Notes |
-|----------|-------|
-| **Regulatory audit** | Provide the full JSON export to DIR or other authorities |
-| **Legal discovery** | Export before or alongside legal hold placement |
-| **Business migration** | Export data before moving to another system |
-| **Off-platform archive** | Retain a copy outside CoralLedger Comply for long-term storage |
-| **Data subject request** | Fulfil a data subject access request (DSAR) |
-
-## Next Steps
+## Next steps
 
 - [Deletion requests](/docs/data-ops/deletion-requests)
 - [Legal holds](/docs/data-ops/legal-holds)
 - [Retention monitoring](/docs/data-ops/retention-monitoring)
-- [Audit trail](/docs/audit)
+- [Audit trail](/docs/audit/)

--- a/docs/data-ops/retention-monitoring.md
+++ b/docs/data-ops/retention-monitoring.md
@@ -6,7 +6,7 @@ description: Data retention policies, enforcement preview, and violation detecti
 
 # Retention Monitoring
 
-CoralLedger Comply enforces per-business data retention policies through scheduled enforcement runs. The default retention period is 7 years, as required by [Value Added Tax Act, 2014, s. 26](https://laws.bahamas.gov.bs/). Operators can review retention schedules, preview upcoming enforcement actions, and investigate detected violations before data is affected.
+CoralLedger Comply enforces per-business data retention policies through scheduled enforcement runs. The default retention period is **7 years** (5-year statutory minimum under [Value Added Tax Act, 2014, Part X §79–80](https://laws.bahamas.gov.bs/); CoralLedger extends this to 7 years as platform policy). Operators can review retention schedules, preview upcoming enforcement actions, and investigate detected violations before data is affected.
 
 ## Accessing Retention Monitoring
 
@@ -18,7 +18,7 @@ All businesses are subject to the platform-wide default:
 
 | Setting | Value | Basis |
 |---------|-------|-------|
-| **Minimum retention period** | 7 years | [Value Added Tax Act, 2014, s. 26](https://laws.bahamas.gov.bs/) |
+| **Minimum retention period** | 7 years (CoralLedger policy; 5-year statutory minimum extended) | [Value Added Tax Act, 2014, Part X §79–80](https://laws.bahamas.gov.bs/) |
 | **Applies to** | Transactions, VAT returns, audit records, uploaded files | — |
 | **Enforcement** | Scheduled; runs on a scheduled basis | — |
 
@@ -76,7 +76,7 @@ The system continuously monitors for retention policy violations — records tha
 
 ### Viewing Violations
 
-Navigate to **Platform Ops > Data Operations > Retention > Violations** to see:
+The retention monitor surface exposes a **HasViolations** indicator on each business's policy summary card. The full per-violation drill-down with the columns below is **planned functionality** — the violation count is computed today via `RetentionMonitorSummary.HasViolations`, but a dedicated violations page is not yet implemented in the Comply UI:
 
 | Column | Description |
 |--------|-------------|
@@ -87,6 +87,8 @@ Navigate to **Platform Ops > Data Operations > Retention > Violations** to see:
 | **Violation Type** | Premature deletion or retention overrun |
 | **Detected On** | When the violation was flagged |
 | **Severity** | Low, Medium, or High |
+
+When a non-zero violation count appears on a business, contact the security team for the underlying detail until the dedicated UI ships.
 
 ### Resolving Violations
 

--- a/docs/security/fraud-alerts.md
+++ b/docs/security/fraud-alerts.md
@@ -10,7 +10,11 @@ CoralLedger Comply's fraud detection system monitors activity in real-time and g
 
 ## Accessing Fraud Alerts
 
-Navigate to **Admin > Fraud Alerts**. This feature requires Administrator access.
+Navigate to **Admin > Fraud Alerts** (route: `/admin/fraud-alerts`). The page requires the Administrator role.
+
+:::note
+Unlike the [Kill Switch](/docs/security/kill-switch) and [IP Blocking](/docs/security/ip-blocking) pages — which gate on both Administrator role **and** 2FA via the `Require2FA` policy — the Fraud Alerts viewer is read-only and currently only role-gated. If your platform deployment requires 2FA for all Admin surfaces, raise the divergence with the security team.
+:::
 
 ## Dashboard Overview
 

--- a/docs/security/ip-blocking.md
+++ b/docs/security/ip-blocking.md
@@ -6,15 +6,15 @@ description: Manage IP address blocking in CoralLedger Comply
 
 # IP Blocking
 
-IP blocking prevents unauthorized access attempts by blocking suspicious IP addresses after repeated failed login attempts.
+IP blocking prevents access from specific IP addresses identified by an Administrator as suspicious or hostile. Blocks operate at the middleware layer — once an IP is blocked, every request from that address is rejected before reaching application logic, not only login attempts.
 
 ## Accessing IP Blocking
 
-Navigate to **Admin > IP Blocking**. This feature requires Administrator access with 2FA enabled.
+Navigate to **Admin > IP Blocking** (route: `/admin/ip-blocking`). This feature requires Administrator access with 2FA enabled.
 
 ## How It Works
 
-When multiple failed login attempts are detected from the same IP address, the system blocks that IP. Administrators can also manually block IPs.
+Administrators manually add IPs to the block list — for example after a [Fraud Alert](/docs/security/fraud-alerts) surfaces suspicious activity from a specific address. There is no automatic IP-block on repeated failed logins today; the operator triages alerts and decides whether to block. Blocks are cached for 30 seconds at the middleware layer for performance.
 
 ## Blocking an IP Address
 

--- a/docs/security/kill-switch.md
+++ b/docs/security/kill-switch.md
@@ -6,19 +6,26 @@ description: Emergency fraud detection control in CoralLedger Comply
 
 # Kill Switch
 
-The kill switch is an emergency control for administrators to immediately disable or override the fraud detection system during security incidents or maintenance.
+The kill switch is an emergency control for administrators to immediately disable the **fraud detection** subsystem during security incidents, high-false-positive periods, or maintenance.
+
+:::warning Scope is fraud detection only
+The kill switch toggles the **fraud detection engine** (`KillSwitchScopes.FraudDetection`). It does **not**:
+
+- Disable the platform as a whole (there is no platform-wide kill switch)
+- Lock individual user accounts (those are managed through `PLATFORM_OPS_USER_LOCKED` actions on the Users admin page, not from this surface)
+- Stop authentication, billing, or any other subsystem
+
+If you need to lock specific accounts during an incident, use the **Ops Portal → Users** admin page and lock the affected accounts there. The kill switch itself is narrowly scoped.
+:::
 
 ## Accessing the Kill Switch
 
-Navigate to **Admin > Kill Switch**. This feature requires Administrator access with 2FA enabled.
+Navigate to **Admin > Kill Switch** (route: `/admin/kill-switch`). This page requires Administrator access with 2FA enabled.
 
-:::info Ops Portal emergency controls
-**PlatformAdmin** operators can also trigger emergency controls — including kill-switch activation and forced account lock-down — directly from the **Ops Portal**.
+:::info Ops Portal access
+PlatformAdmin operators can also reach kill-switch state through Ops Portal surfaces. All Ops Portal actions require the `RequirePlatformAdmin` policy (role + completed 2FA challenge) and are recorded in the platform-level audit log.
 
-- All Ops Portal actions require the [`RequirePlatformAdmin` policy](/docs/security#requireplatformadmin-policy) (role + 2FA check).
-- Ops Portal events are recorded in the **platform-level audit log**, separately from business-level audit entries.
-
-See [Security Overview](/docs/security) for details on the PlatformAdmin role and self-operation guards.
+See [Security Overview](/docs/security/) for details on the PlatformAdmin role and self-operation guards.
 :::
 
 ## Status Display


### PR DESCRIPTION
## Summary

Targeted accuracy edits across 5 pages (3 Security + 2 Data Ops with full rewrite on data-export). Highest-impact corrections from Phase 4 audit.

## Security highlights

- **ip-blocking.md** — removed false 'auto-block on failed logins' claim; reframed as manual operator action
- **fraud-alerts.md** — added honest note that this page does NOT require 2FA (divergence from kill-switch + ip-blocking)
- **kill-switch.md** — prominent warning that scope is fraud detection ONLY; no platform-wide kill / account lockdown from this UI

## Data Ops highlights

- **retention-monitoring.md** — statute citation corrected: VAT Act Part X §79–80 (was: s.26 incorrect). Violations dashboard reframed as planned-not-shipped.
- **data-export.md** — full rewrite. Two paths: tenant Admin UI shipped + Ops Portal service-only. Removed aspirational queueing / Export History / status enum claims.

## Verification

- Docusaurus build: green
- All cross-links resolve

## Closes

- #188 — Security accuracy
- #189 — Data Ops accuracy

## Cass retroactive sign-off requested

The retention statute citation correction (Part X §79–80) is regulatorily significant.

## Cross-reference

- Phase 4 epic: #185
- Code: IpBlockingService.cs, FraudDetectionKillSwitch.cs, RetentionPolicyService.cs (LegalReference constant), PlatformDataOpsService.cs