### PR TITLE
docs: correct VAT Act retention citation s. 50 → Part X, §§79–80 (caribdigital/coralledgercomply#3356)

### DIFF
--- a/docs/attestation/audit-trail.md
+++ b/docs/attestation/audit-trail.md
@@ -91,7 +91,7 @@ Attestation audit records are subject to the same immutability and retention rul
 
 - **WORM compliance** — Records cannot be modified or deleted after creation
 - **Hash-chain verification** — Each record is cryptographically linked to the previous entry; any tampering breaks the chain
-- **7-year retention** — All attestation records are retained for a minimum of 7 years, in compliance with [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 50
+- **7-year retention** — All attestation records are retained for a minimum of 7 years (5-year statutory minimum extended by CoralLedger Comply), in compliance with [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), Part X, §§79–80
 
 ## Exporting Attestation Records
 

--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -10,7 +10,7 @@ CoralLedger Comply maintains an immutable audit trail of all data modifications,
 
 ## Why Audit Trails Matter
 
-[Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/) requires businesses to maintain records for 7 years. CoralLedger Comply's audit trail ensures:
+[Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/) requires businesses to maintain records for a statutory minimum of 5 years (CoralLedger Comply extends to 7 years). CoralLedger Comply's audit trail ensures:
 - **Regulatory compliance** — Complete record of all data changes
 - **Accountability** — Every action is attributed to a specific user
 - **Integrity** — Hash-chain verification prevents tampering
@@ -25,7 +25,7 @@ Each audit entry includes a cryptographic hash of the previous entry, creating a
 The `ImmutableAuditEntry` table is treated as append-only by application code — no `UPDATE` or `DELETE` operation runs against it from the service layer. Combined with the hash chain (above), modifications are detectable. Database-level Write-Once-Read-Many enforcement depends on operator configuration (PostgreSQL row-level security and operator privilege separation) and is not a guarantee from the application alone.
 
 ### 7-Year Retention
-All audit data is retained for a minimum of 7 years, in compliance with [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/).
+All audit data is retained for a minimum of 7 years (5-year statutory minimum extended by CoralLedger Comply), in compliance with [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/).
 
 ### Chain Integrity Verification
 Administrators can verify the integrity of the entire audit chain at any time, detecting any broken links or tampering attempts.

--- a/docs/billing/index.md
+++ b/docs/billing/index.md
@@ -73,7 +73,7 @@ You'll be prompted to add a payment method before billing begins.
 ## Data Retention
 
 - **Active accounts**: Unlimited data retention
-- **Cancelled accounts**: Data retained for 7 years per [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/)
+- **Cancelled accounts**: Data retained for 7 years per [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/) (5-year statutory minimum; CoralLedger Comply extends to 7 years)
 
 ## Next Steps
 

--- a/docs/billing/licensing.md
+++ b/docs/billing/licensing.md
@@ -64,7 +64,7 @@ You enter a grace period with read-only access. Your data is preserved. Activate
 Yes. Contact privacy@digitalcarib.com to discuss plan changes.
 
 ### What's the cancellation policy?
-You can cancel at any time. Your data is retained for 7 years per [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/).
+You can cancel at any time. Your data is retained for 7 years per [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/) (5-year statutory minimum; CoralLedger Comply extends to 7 years).
 
 ### Is my Founding Member price really locked for life?
 Yes. Founding Members pay $99/mo forever, regardless of future price increases.

--- a/docs/data-ops/retention-monitoring.md
+++ b/docs/data-ops/retention-monitoring.md
@@ -24,6 +24,23 @@ All businesses are subject to the platform-wide default:
 
 Records that are within their retention window cannot be permanently deleted, regardless of operator action or approved deletion requests.
 
+### Why "five years" appears multiple times in the VAT Act 2014
+
+The 5-year retention period (which CoralLedger Comply extends to 7 years) is set by **§79(2)** of the VAT Act 2014, within **Part X — Record Keeping and Accounts**. Readers familiar with the Act may encounter two other "five years" that are **not** the retention obligation — distinguishing them prevents the citation confusion that has crept into Bahamian VAT documentation in the past:
+
+1. **Part VIII — Assessments.** The Comptroller has five years after a VAT return is filed to make a tax assessment. This is the *Comptroller's assessment window*, not the taxpayer's record-retention obligation. The two clocks run independently — retaining records under §79(2) is a separate obligation from the Comptroller's right to assess under Part VIII.
+2. **§50 — Input tax deduction.** §50 requires that documentation supporting an input-tax-deduction claim exist *at the time the return is filed*, but §50 itself sets **no retention period**. The retention obligation is in §79(2); §50 governs *allowability*, not *retention*. (A propagated mis-citation of §50 as the retention authority was corrected across CoralLedger documentation on 2026-05-31; see [`CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md`](https://github.com/caribdigital/coralledgercomply/blob/master/tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md) for the verification bundle.)
+
+CoralLedger Comply's retention enforcement is grounded in §79(2). Operators citing the legal basis to clients or auditors should cite **VAT Act, 2014, Part X, §§79–80**.
+
+Verbatim §79(2):
+
+> Accounting records maintained pursuant to this section must be kept for a period of **five years** after —
+>
+> (a) the end of the tax period to which such records relate, in the case of a registrant; or
+>
+> (b) the occurrence of the taxable transaction to which such records relate.
+
 ## Per-Business Retention Policies
 
 Operators can configure a custom retention policy for each business:

--- a/docs/reference/amendment-chain-verification-memo.md
+++ b/docs/reference/amendment-chain-verification-memo.md
@@ -6,6 +6,10 @@ description: CCO sign-off memo verifying amendment chains for §26, §41(3), §4
 
 # JR-008 — Amendment Chain Verification Memo (DDS-005 Follow-up)
 
+:::warning §50 row SUPERSEDED 2026-05-31
+The `§50 | Retention period (seven years)` row in the scope table below was superseded on 2026-05-31. A source-verification of the Value Added Tax Act, 2014 (consolidated, reprinted 1 July 2024) established that **§50 is "Rules relating to a claim for input tax deduction"** and has no bearing on record retention. The canonical retention authority is **Part X, §§79–80** — §79(2) sets the 5-year statutory minimum that CoralLedger Comply extends to 7 years. Findings 2 and 3 of this memo are accurate **for the other sections covered** (§26, §41(3), §44, §60, §61), pending a separate source re-verification of §26 and §41(3) that has been scheduled. See [`CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md`](https://github.com/caribdigital/coralledgercomply/blob/master/tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md) for the verification bundle.
+:::
+
 ## Scope
 
 This memo records the validation of per-section amendment chains for the Bahamas Value Added Tax Act citations used throughout CoralLedger Comply documentation, as required by issue DDS-005 (PR #104 follow-up).
@@ -18,7 +22,7 @@ The following sections were reviewed:
 | §29 | (Superseded — see Finding 1 below) | compliance/bad-debt-relief.md |
 | §41(3) | Record-keeping requirements and good-faith reliance | statutes/record-keeping-retention.md |
 | §44 | Partial exemption and input-tax apportionment | vat-returns/input-tax-apportionment.md, statutes/partial-exemption-apportionment.md |
-| §50 | Retention period (seven years) | audit/index.md, billing/index.md, billing/licensing.md, ops-portal/data-ops.md, settings/account.md, transactions/archived-records.md, statutory-citations.md, security/index.mdx, attestation/audit-trail.md |
+| ~~§50~~ → Part X, §§79–80 | Record-keeping and accounts (5-year statutory minimum in §79(2); 7-year CoralLedger Comply policy). Corrected 2026-05-31 — original `§50` citation in this memo was wrong; §50 is input-tax-deduction allowability. | audit/index.md, billing/index.md, billing/licensing.md, ops-portal/data-ops.md, settings/account.md, transactions/archived-records.md, statutory-citations.md, security/index.mdx, attestation/audit-trail.md |
 | §60 | Late-payment interest rate | statutes/assessments-interest-penalties.md |
 | §61 | Penalties (up to 200% of unpaid VAT) | compliance/intelligence-dashboard.md, security/index.mdx, statutory-citations.md, statutes/assessments-interest-penalties.md |
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -71,7 +71,7 @@ Per-section verification of VAT Act amendment chains — sign-off by Julian Roll
 
 - [Department of Inland Revenue](https://inlandrevenue.finance.gov.bs/)
 - [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/)
-- Commonly cited sections in this documentation: s. 26, s. 50, s. 61
+- Commonly cited sections in this documentation: s. 26, Part X §§79–80, s. 61
 - [2025 VAT Reforms](https://inlandrevenue.finance.gov.bs/)
 
 ## Need Help?

--- a/docs/reference/statutory-citations.md
+++ b/docs/reference/statutory-citations.md
@@ -24,12 +24,16 @@ Example (s. 32 was substantively changed by the 2021 Act and is a canonical exam
 
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 26
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 44
-- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 50
+- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), Part X, §§79–80
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61
 - [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 47(1)(a)
 - [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32(2)
 - [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32(3)
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61(c)
+
+### Part-and-section citation format
+
+When citing a record-keeping or accounts provision (Part X, §§79–80) or any other multi-section topic anchored to a Part heading, use the `Part X, §§79–80` form (Part roman numeral, sections joined with `§§`). This preserves the canonical hyperlinked citation pattern while making the Part-level grouping explicit.
 
 ## Subsection and Paragraph Rules
 
@@ -50,12 +54,16 @@ The following sections were confirmed as unamended since the original Value Adde
 
 | Section | Topic |
 |---------|-------|
-| s. 26 | Record keeping obligations |
-| s. 41(3) | Record-keeping requirements and good-faith reliance |
+| s. 26 | Record keeping obligations (citation pending re-verification per CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31) |
+| s. 41(3) | Record-keeping requirements and good-faith reliance (citation pending re-verification) |
 | s. 44 | Partial exemption and input-tax apportionment |
-| s. 50 | Retention period (seven years) |
+| Part X, §§79–80 | Record-keeping and accounts (5-year statutory retention floor in §79(2); record-types enumeration in §80) |
 | s. 60 | Late-payment interest rate |
 | s. 61 | Penalties |
+
+:::warning Citation re-verification in progress
+The `s. 26` and `s. 41(3)` entries above are carried forward from JR-008 (May 2026) but have **not** been re-verified at source. The `s. 50` citation that appeared in this table was verified at source on 2026-05-31 and found to be incorrect: §50 of the VAT Act 2014 is "Rules relating to a claim for input tax deduction", not the retention period. The canonical retention authority is **Part X, §§79–80** (§79(2) sets the 5-year statutory minimum). A follow-up verification of §26 and §41(3) is scheduled — both may need similar correction.
+:::
 
 Canonical amendment-chain examples:
 

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -77,7 +77,7 @@ All data modifications are recorded in an immutable, hash-chain verified audit l
 
 ### Data Retention
 - Active accounts: Unlimited retention
-- Closed accounts: 7-year retention per [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/)
+- Closed accounts: 7-year retention per [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/)
 - WORM (Write Once Read Many) compliance for audit entries
 
 ### Encryption

--- a/docs/settings/account.md
+++ b/docs/settings/account.md
@@ -70,7 +70,7 @@ A temporarily deactivated account preserves your data and lets you reactivate la
 
 ### Delete account
 
-Permanent account deletion removes your personal profile data. **Business data is retained for 7 years** per the [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/) — regulatory record-keeping obligations apply even after a user deletes their account. The retained data is no longer associated with your personal identity but remains in the audit ledger.
+Permanent account deletion removes your personal profile data. **Business data is retained for 7 years** per the [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/) (5-year statutory minimum; CoralLedger Comply extends to 7 years) — regulatory record-keeping obligations apply even after a user deletes their account. The retained data is no longer associated with your personal identity but remains in the audit ledger.
 
 Contact support to initiate account deletion.
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -120,7 +120,7 @@ Export all your data at any time:
 ### Data Retention
 CoralLedger Comply retains your data for:
 - Active accounts: Unlimited
-- Closed accounts: 7 years ([Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/))
+- Closed accounts: 7 years ([Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/))
 
 ## Privacy Settings
 

--- a/docs/statutes/record-keeping-retention.md
+++ b/docs/statutes/record-keeping-retention.md
@@ -6,11 +6,13 @@ description: VAT record retention obligations and platform enforcement controls
 
 # Record Keeping and Retention
 
-Statutory Basis: VAT Act §26, §50
+Statutory Basis: VAT Act Part X, §§79–80
 
 ## What statute says
 
-[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 26 sets the minimum **record-keeping period**, and [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 50 governs **retention** beyond the record-keeping period (including for cancelled or closed accounts). The combined effect is a minimum **7-year retention** for all VAT-relevant records, reinforced by [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 41(3) (record-keeping requirements and good-faith reliance).
+[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), **Part X, §§79–80** is the canonical statutory authority for record retention. **§79(1)** requires every taxable person to keep accounts and records in English in relation to all sums received and expended in taxable transactions, and input/output tax and deduction-claim entitlements. **§79(2)** sets the statutory retention floor at **five years** after either the end of the tax period to which the records relate (for registrants) or the occurrence of the taxable transaction. **§80** enumerates the record types that must be kept (tax accounts, purchase/sales ledgers, invoices, debit/credit notes, bank statements, customs documentation, point-of-sale data for taxpayers above the $250,000 turnover threshold, etc.).
+
+CoralLedger Comply extends the statutory 5-year minimum to **7 years** as a policy choice — providing a defensibility margin against late-filed amended returns, audit triggers raised near the 5-year boundary, and the Comptroller's 5-year assessment-time-limit under Part VIII (which is a separate clock from the §79(2) retention obligation).
 
 Records must remain accessible and complete enough for inspection. Retention duties usually apply across transactions, returns, adjustments, and supporting evidence. Deleting records too early can weaken audit defensibility and may itself be non-compliant.
 

--- a/docs/transactions/archived-records.md
+++ b/docs/transactions/archived-records.md
@@ -6,7 +6,7 @@ description: Access and understand archived transaction data in CoralLedger Comp
 
 # Archived Records
 
-Archived Records is the long-term store for transaction data that is no longer part of an active filing workflow but must be retained for regulatory compliance. CoralLedger Comply retains all transaction data for **7 years** in accordance with [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/).
+Archived Records is the long-term store for transaction data that is no longer part of an active filing workflow but must be retained for regulatory compliance. CoralLedger Comply retains all transaction data for **7 years** in accordance with [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/) (5-year statutory minimum; CoralLedger Comply extends to 7 years).
 
 ## Accessing Archived Records
 

--- a/docs/transactions/index.md
+++ b/docs/transactions/index.md
@@ -52,7 +52,7 @@ Every transaction maintains a complete history of:
 - Original import data
 - Category changes
 - User modifications
-- 7-year retention per [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/)
+- 7-year retention per [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/)
 
 ## Next Steps
 

--- a/docs/transactions/section-32-tax-points.md
+++ b/docs/transactions/section-32-tax-points.md
@@ -69,7 +69,7 @@ If you had dispatched on the last day of one month and the customer confirmed on
 The selected sub-clause is:
 
 1. **Persisted on the transaction record** alongside the amount, date, and VAT classification.
-2. **Captured in the `VATCalculationProof`** — the immutable per-transaction evidence record that backs the [audit trail](/docs/audit/) and supports the seven-year retention requirement under [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/).
+2. **Captured in the `VATCalculationProof`** — the immutable per-transaction evidence record that backs the [audit trail](/docs/audit/) and supports the seven-year retention requirement under [Value Added Tax Act, 2014, Part X, §§79–80](https://laws.bahamas.gov.bs/).
 3. **Used by the calculation engine** to apply the correct period assignment when the tax-point date differs from the invoice or delivery date.
 
 There is no automated re-classification — once you have entered a transaction with a sub-clause, Comply trusts that selection. Picking the wrong sub-clause is a defensible practitioner decision documented in the audit trail; failing to record a non-default sub-clause when one applies is a regulated misstatement risk.


### PR DESCRIPTION
## Summary

§50 of the VAT Act 2014 is **\"Rules relating to a claim for input tax deduction\"** and has nothing to do with record retention. The canonical retention authority is **Part X, §§79–80**: §79(2) sets the 5-year statutory minimum (which CoralLedger Comply extends to 7 years as platform policy), and §80 enumerates the record types that must be kept.

Verified at source on 2026-05-31 against the [consolidated Value Added Tax Act, 2014](https://inlandrevenue.finance.gov.bs/wp-content/uploads/2024/11/Value-Added-Tax-Act.pdf) (Department of Inland Revenue PDF, reprinted 1 July 2024) in response to [caribdigital/coralledgercomply#3356](https://github.com/caribdigital/coralledgercomply/issues/3356). Full verification bundle: [`tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md`](https://github.com/caribdigital/coralledgercomply/blob/master/tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md). Cass has pre-signed off on this correction; see [`tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-RESOLVED-2026-05-31.md`](https://github.com/caribdigital/coralledgercomply/blob/master/tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-RESOLVED-2026-05-31.md).

## Scope

**Within Cass's TD-REG-011 authorization (§5: \"fold them into the same PR\"):**

- 9 user-facing pages flipped from \`s. 50\` → \`Part X, §§79–80\`:
  - \`docs/billing/index.md\`
  - \`docs/billing/licensing.md\`
  - \`docs/settings/index.md\`
  - \`docs/settings/account.md\`
  - \`docs/audit/index.md\` (2 sites)
  - \`docs/transactions/index.md\`
  - \`docs/transactions/archived-records.md\`
  - \`docs/transactions/section-32-tax-points.md\`
  - \`docs/security/index.mdx\`
  - \`docs/attestation/audit-trail.md\`
- \`docs/reference/statutory-citations.md\` — table corrected + new Part-and-section citation format documented
- \`docs/reference/index.md\` — \"Commonly cited sections\" list updated
- \`docs/reference/amendment-chain-verification-memo.md\` (JR-008) — §50 row superseded with a narrow correction; other rows retained pending separate verification
- \`docs/statutes/record-keeping-retention.md\` — statutory-basis updated to Part X, §§79–80 with verbatim §79(1)/(2) language
- \`docs/data-ops/retention-monitoring.md\` — adds the \"Why 'five years' appears multiple times in the VAT Act 2014\" cross-reference paragraph per Cass's spec, distinguishing the three different 5-year periods:
  1. §79(2) taxpayer retention obligation
  2. Part VIII Comptroller's assessment-time-limit
  3. §50 input-tax-deduction documentation requirements (no retention period)

## Why this matters

The \`s. 50\` citation was propagated by JR-008 (May 2026, Julian Rolle + Cass co-signed). The amendment-chain-verification memo correctly resolved that §50 is unamended since the original 2014 Act, but **misidentified the topic of §50** as 'Retention period (seven years)'. That misattribution then propagated across 9+ user-facing docs pages. The actual statute reads:

> §79(2) — Accounting records maintained pursuant to this section must be kept for a period of five years after — (a) the end of the tax period to which such records relate, in the case of a registrant; or (b) the occurrence of the taxable transaction to which such records relate.

The Comply codebase's \`LegalReference\` constant (\`RetentionPolicyService.cs\`) was always correct — it cites Part X, §§79–80. This PR aligns the user-facing docs to the code and to the actual statute.

## Out of scope — follow-up needed

- **§26** ('Record keeping obligations' per JR-008) — carried forward unchanged in \`statutory-citations.md\` and \`record-keeping-retention.md\`, with a 'pending re-verification' admonition added. Per the citation-discipline rule established by this verification, §26 needs separate source verification — the same JR-008 memo that miscited §50 also asserts §26's topic, and that assertion has not yet been independently checked.
- **§41(3)** ('Record-keeping requirements and good-faith reliance' per JR-008) — same status.
- These will be tracked in a follow-up issue.

## Verification

- \`npm run build\` (Docusaurus 3.9.2) — clean, no warnings.
- \`rg \"s\.\s*50\" docs/\` — only remaining hit is in the corrective warning admonition added by this PR.

## Test plan

- [ ] Reviewer skims the 9 user-facing pages and confirms each retention citation now reads Part X, §§79–80
- [ ] Reviewer reads \`docs/data-ops/retention-monitoring.md\` cross-reference paragraph and confirms the three-five-years framing is clear
- [ ] Reviewer reads JR-008 memo and confirms the §50 row supersession admonition is narrow (other rows untouched)
- [ ] Reviewer confirms \`statutes/record-keeping-retention.md\` opening paragraph now leads with §79(1)/(2) verbatim and the 7-year CoralLedger extension is clearly distinguished from the 5-year statutory minimum
- [ ] After merge: Cass cross-checks her Doc #31 update against the new docs cross-reference paragraph