### PR TITLE
Remove 12 'Walkthrough video coming soon' placeholder callouts (Closes #150)

### DIFF
--- a/docs/compliance/compliance-score.mdx
+++ b/docs/compliance/compliance-score.mdx
@@ -8,15 +8,6 @@ description: Understanding your CoralLedger Comply compliance score
 
 Your compliance score helps you understand your VAT compliance health at a glance.
 
-## Compliance Walkthrough
-
-:::info Walkthrough videos coming soon
-Demo recordings of this workflow will be added here. Topics:
-
-- Score overview and grading
-- Improving your score
-:::
-
 ## Score Grades
 
 | Grade | Score Range | Status |

--- a/docs/firm-portal/index.mdx
+++ b/docs/firm-portal/index.mdx
@@ -8,16 +8,6 @@ description: Manage multiple client businesses in CoralLedger Comply
 
 The Firm Portal is the central surface for accounting professionals managing VAT compliance across multiple client businesses. It exposes the firm-wide dashboard, the client grid with search, batch and per-client filing surfaces, multi-client reporting, staff productivity, and (where applicable) the §32 attestation entry pathway for restricted-segment clients.
 
-## Client Management Walkthrough
-
-:::info Walkthrough videos coming soon
-Demo recordings of this workflow will be added here. Topics:
-
-- Multi-client dashboard
-- Adding and managing clients
-- Batch filing workflow
-:::
-
 ## Who uses the Firm Portal
 
 - **Accounting firms** managing client VAT compliance under a single firm umbrella

--- a/docs/getting-started/create-account.mdx
+++ b/docs/getting-started/create-account.mdx
@@ -14,17 +14,6 @@ CoralLedger Comply is currently in free beta. All features are available at no c
 **Founding Member Special**: Lock in $99/mo for life — limited to 20 spots.
 :::
 
-## Registration Walkthrough
-
-:::info Walkthrough videos coming soon
-Demo recordings of this workflow will be added here. Topics:
-
-- Sign-up form
-- Email verification
-- Two-factor authentication setup
-- Business setup
-:::
-
 ## The four-step wizard
 
 The registration form is a wizard with four ordered steps. You complete each step before advancing; the form persists what you've entered locally for 24 hours so you can return to a partial submission.

--- a/docs/getting-started/mobile.mdx
+++ b/docs/getting-started/mobile.mdx
@@ -8,12 +8,6 @@ description: Using CoralLedger Comply from a phone or tablet — responsive web 
 
 CoralLedger Comply is a **responsive web application** — it adapts its layout to phones, tablets, and desktops without needing a separate mobile app. There is no App Store / Play Store install; you access the platform from your device's browser the same way you would on a laptop.
 
-## Mobile Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of the responsive interface on phone and tablet will be added here.
-:::
-
 ## Supported Devices
 
 - **Smartphones** — iOS Safari and Android Chrome

--- a/docs/getting-started/performance.mdx
+++ b/docs/getting-started/performance.mdx
@@ -8,12 +8,6 @@ description: How CoralLedger Comply is built for responsive interactivity, large
 
 CoralLedger Comply is built on a server-rendered Blazor architecture that prioritises responsiveness on Caribbean network conditions. This page documents the actual performance properties of the platform rather than aspirational targets.
 
-## Performance Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of fast load times and the responsive UI will be added here.
-:::
-
 ## How the platform is built
 
 Comply runs as a Blazor Server application — UI rendering happens on the server, with the browser maintaining a SignalR connection over which DOM updates flow. This architecture has specific performance properties:

--- a/docs/reference/vat-rates.mdx
+++ b/docs/reference/vat-rates.mdx
@@ -8,12 +8,6 @@ description: Complete VAT rate reference for The Bahamas
 
 Current VAT rates under the Bahamas VAT legal framework and 2025 reforms.
 
-## Rate Transition Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of rate transition guidance and date-based application will be added here.
-:::
-
 ## Category Summary
 
 | Category | Name | Application |

--- a/docs/reports/index.mdx
+++ b/docs/reports/index.mdx
@@ -8,12 +8,6 @@ description: Financial reports and analytics in CoralLedger Comply
 
 CoralLedger Comply provides comprehensive reporting tools to help you analyze your VAT position, cash flow, and business performance.
 
-## Exports Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of export formats and download options will be added here.
-:::
-
 ## Available Reports
 
 ### Analytics Dashboard

--- a/docs/reports/shared-reports.mdx
+++ b/docs/reports/shared-reports.mdx
@@ -8,12 +8,6 @@ description: Share reports securely with clients and auditors
 
 Generate secure, shareable links to reports for clients, auditors, or team members without requiring them to have a CoralLedger Comply account.
 
-## Share Links Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of creating and managing secure share links will be added here.
-:::
-
 ## How It Works
 
 1. Generate a report (VAT return, transaction list, etc.)

--- a/docs/security/index.mdx
+++ b/docs/security/index.mdx
@@ -8,12 +8,6 @@ description: Security features in CoralLedger Comply
 
 CoralLedger Comply implements multiple layers of security to protect your financial data and ensure regulatory compliance.
 
-## Multi-Tenant Security Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of multi-tenant isolation and role-based access control will be added here.
-:::
-
 ## Authentication
 
 ### Two-Factor Authentication (2FA)

--- a/docs/transactions/import-csv.mdx
+++ b/docs/transactions/import-csv.mdx
@@ -8,12 +8,6 @@ description: Import transactions from CSV files into CoralLedger Comply
 
 Upload your transaction data from any accounting system using CSV files.
 
-## CSV Import Walkthrough
-
-:::info Walkthrough video coming soon
-A demo recording of CSV import and column mapping will be added here.
-:::
-
 ## Supported Formats
 
 CoralLedger Comply accepts CSV files with the following columns:

--- a/docs/transactions/manual-entry.mdx
+++ b/docs/transactions/manual-entry.mdx
@@ -8,15 +8,6 @@ description: Enter transactions directly in CoralLedger Comply
 
 Enter individual transactions directly when you don't have a CSV file or need to record one-off transactions.
 
-## Manual Entry Walkthrough
-
-:::info Walkthrough videos coming soon
-Demo recordings of this workflow will be added here. Topics:
-
-- Quick entry and advanced mode
-- Multi-line and multi-rate entry
-:::
-
 ## When to Use Manual Entry
 
 - Recording cash transactions

--- a/docs/vat-returns/generate-return.mdx
+++ b/docs/vat-returns/generate-return.mdx
@@ -8,17 +8,6 @@ description: Create your VAT return in CoralLedger Comply
 
 Create your VAT return with a single click using your imported transactions. The system calculates all L1-L31 DIR form fields from your reviewed and categorized transactions, ready for your final review before submission.
 
-## VAT Returns Walkthrough
-
-:::info Walkthrough videos coming soon
-Demo recordings of this workflow will be added here. Topics:
-
-- Selecting a period and reviewing summary
-- Validation and compliance checks
-- Generating and exporting returns
-- Amendments and corrections
-:::
-
 ## Prerequisites
 
 Before generating a return:


### PR DESCRIPTION
Closes #150.

12 placeholder callouts removed from pages that now substantively walk through their workflows in text. The Phase 1-4 rewrites already cover the content these video callouts were placeholders for.

## Files (12)

- docs/getting-started/{create-account,mobile,performance}.mdx
- docs/transactions/{manual-entry,import-csv}.mdx
- docs/vat-returns/generate-return.mdx
- docs/firm-portal/index.mdx
- docs/compliance/compliance-score.mdx
- docs/reports/{index,shared-reports}.mdx
- docs/security/index.mdx
- docs/reference/vat-rates.mdx

## What remains

- DemoVideo component left in place for future re-introduction if videos are eventually recorded
- cdn.coralledger.com still non-existent (no change there)

## Verification

- Docusaurus build: green
- Sitewide grep for 'Walkthrough video coming soon': 0 hits