### PR TITLE
Add Playwright video recorder infrastructure (#150 long-term step 1)

### DIFF
--- a/scripts/playwright-recorder/.gitignore
+++ b/scripts/playwright-recorder/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+recordings/
+dist/
+package-lock.json

--- a/scripts/playwright-recorder/README.md
+++ b/scripts/playwright-recorder/README.md
@@ -1,0 +1,71 @@
+# Playwright video recorder
+
+Captures demo videos of authenticated CoralLedger Comply workflows on the staging environment, for use on the documentation site.
+
+Pairs with `scripts/convert-marketing-videos.sh` for `.webm` → `.mp4` conversion.
+
+## Prerequisites
+
+- Node 18+
+- Playwright Chromium browser installed (one-time)
+- `STAGING_TEST_AUTH_SECRET` env var set to the staging TestAuth bypass secret. Same value used by the Comply Reef smoke suite — see `tests/CoralComply.E2E.Tests/Smoke/SmokeTestConfig.cs` in the Comply repo.
+
+## Install
+
+```bash
+cd scripts/playwright-recorder
+npm install
+npm run install:browsers
+```
+
+## Run a single scenario
+
+```bash
+export STAGING_TEST_AUTH_SECRET=<the staging secret>
+node run.js compliance-01
+```
+
+This writes `recordings/compliance-01.webm`.
+
+## Run all scenarios
+
+```bash
+export STAGING_TEST_AUTH_SECRET=<the staging secret>
+node run.js --all
+```
+
+## Convert WebM → MP4
+
+```bash
+cd ../..   # back to docs repo root
+./scripts/convert-marketing-videos.sh scripts/playwright-recorder/recordings dist/videos
+```
+
+## Upload to CDN
+
+Once the `cdn.coralledger.com` host is provisioned (Azure Blob + Front Door), upload the produced `.mp4` files to `https://cdn.coralledger.com/demos/`. The `DemoVideo` component on the docs site (`src/components/DemoVideo/`) already targets that path.
+
+## Scenarios
+
+| id | Target docs page | CDN file |
+|---|---|---|
+| `compliance-01` | `docs/compliance/compliance-score.mdx` | `compliance-01.mp4` |
+| `exports-01` | `docs/reports/index.mdx` | `exports-01.mp4` |
+
+More scenarios will be added as the proof-of-concept work expands.
+
+## Authentication
+
+The recorder authenticates against staging using the **TestAuth bypass** — the same path the Reef smoke suite uses (see `tests/CoralComply.E2E.Tests/Smoke/SmokeTestBase.cs:240-303` in the Comply repo). The bypass attaches the `X-TestAuth-Secret` header to requests matching `**/api/test-auth/**`; once authenticated, the standard auth cookies carry the session.
+
+Default test user: `ksaconsultantsltd@gmail.com` — the Accounting Firm Owner with full Owner permissions on the staging dataset.
+
+## Adding a new scenario
+
+1. Create `scenarios/<id>.js`. The module must `export default` an object with `id`, `title`, optional `viewport`, and an `async record({ page, log })` function.
+2. Use `authenticateViaTestAuth(page, ...)` from `lib/auth.js` to log in.
+3. Drive the workflow with Playwright. The `BrowserContext` is configured to record video for the entire run.
+4. Run with `node run.js <id>` to test.
+5. Convert and upload as above.
+
+Recording produces `recordings/<id>.webm`. The `recordings/` directory is gitignored — never commit the produced binaries; they live on the CDN.

--- a/scripts/playwright-recorder/lib/auth.js
+++ b/scripts/playwright-recorder/lib/auth.js
@@ -1,0 +1,65 @@
+// TestAuth bypass helper.
+//
+// Mirrors the C# SmokeTestBase.AuthenticateViaTestAuthAsync pattern at
+// tests/CoralComply.E2E.Tests/Smoke/SmokeTestBase.cs:240-303 (CoralComply repo).
+//
+// The bypass works like this:
+//   1. We register a request-route handler on `**/api/test-auth/**` that injects the
+//      X-TestAuth-Secret header into every request matching that pattern.
+//   2. We navigate to `<baseUrl>/api/test-auth/login?email=<email>&redirectTo=<path>`.
+//      The TestAuthController on the target environment validates the header against the
+//      configured TestAuth:StagingSecret, then issues the standard auth cookies and
+//      redirects to `redirectTo`.
+//   3. We tear the route handler down once authenticated — the cookies travel via the
+//      normal cookie jar from this point on, so we never need to send the secret again.
+//
+// Required env var: STAGING_TEST_AUTH_SECRET.
+// Default user:     ksaconsultantsltd@gmail.com (Accounting Firm Owner with full perms).
+//
+// Reference: tests/CoralComply.E2E.Tests/Smoke/SmokeTestBase.cs lines 240-303 in caribdigital/coralledgercomply
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {object} [opts]
+ * @param {string} [opts.baseUrl] - Defaults to https://stg-comply.coralledger.com.
+ * @param {string} [opts.email]   - Defaults to ksaconsultantsltd@gmail.com.
+ * @param {string} [opts.redirectTo] - Defaults to /dashboard.
+ */
+export async function authenticateViaTestAuth(page, opts = {}) {
+  const baseUrl = opts.baseUrl ?? process.env.SMOKE_BASE_URL ?? 'https://stg-comply.coralledger.com';
+  const email = opts.email ?? 'ksaconsultantsltd@gmail.com';
+  const redirectTo = opts.redirectTo ?? '/dashboard';
+
+  const secret = process.env.STAGING_TEST_AUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      'STAGING_TEST_AUTH_SECRET is not set. Set it in your shell before running the recorder.'
+    );
+  }
+
+  const routePattern = '**/api/test-auth/**';
+
+  // Attach the secret only to TestAuth routes — scope keeps the secret out of any
+  // other request that happens to share the navigation.
+  await page.route(routePattern, async (route) => {
+    const headers = { ...route.request().headers(), 'x-testauth-secret': secret };
+    await route.continue({ headers });
+  });
+
+  try {
+    const loginUrl =
+      `${baseUrl}/api/test-auth/login` +
+      `?email=${encodeURIComponent(email)}` +
+      `&redirectTo=${encodeURIComponent(redirectTo)}`;
+
+    const response = await page.goto(loginUrl, { waitUntil: 'networkidle' });
+    if (!response || response.status() >= 400) {
+      throw new Error(
+        `TestAuth login failed: HTTP ${response ? response.status() : 'no response'}. ` +
+          `Check STAGING_TEST_AUTH_SECRET + TestAuth:StagingSecret on the target env.`
+      );
+    }
+  } finally {
+    await page.unroute(routePattern);
+  }
+}

--- a/scripts/playwright-recorder/lib/recorder.js
+++ b/scripts/playwright-recorder/lib/recorder.js
@@ -1,0 +1,84 @@
+// Per-scenario recording driver.
+//
+// Each scenario module exports:
+//   - id          (string)  - matches the target .mp4 name in cdn.coralledger.com/demos/<id>.mp4
+//   - title       (string)  - human-readable; used in run logs
+//   - viewport    (object)  - { width, height }
+//   - record      (async fn) - receives { page, log } and drives the workflow
+//
+// The recorder wraps each scenario in a fresh BrowserContext with `recordVideo`. The .webm
+// file is finalised when the context closes. The downstream conversion to .mp4 is handled
+// by scripts/convert-marketing-videos.sh (existing).
+
+import { chromium } from 'playwright';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const recordingsDir = path.join(projectRoot, 'recordings');
+
+/**
+ * @param {object} scenario
+ * @param {string} scenario.id
+ * @param {string} scenario.title
+ * @param {{width:number,height:number}} [scenario.viewport]
+ * @param {(ctx:{page:import('playwright').Page, log:(msg:string)=>void}) => Promise<void>} scenario.record
+ */
+export async function runScenario(scenario) {
+  const viewport = scenario.viewport ?? { width: 1280, height: 720 };
+
+  // Ensure recordings/ exists.
+  fs.mkdirSync(recordingsDir, { recursive: true });
+
+  const log = (msg) => console.log(`[${scenario.id}] ${msg}`);
+
+  log(`Starting recording — ${scenario.title}`);
+  log(`Viewport: ${viewport.width}x${viewport.height}`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport,
+    recordVideo: {
+      dir: recordingsDir,
+      size: viewport,
+    },
+  });
+  const page = await context.newPage();
+
+  let outcome = 'failed';
+  let videoPath;
+  try {
+    await scenario.record({ page, log });
+    outcome = 'ok';
+  } catch (err) {
+    log(`ERROR: ${err.message}`);
+    throw err;
+  } finally {
+    // Capture the video object BEFORE context.close() so we can rename the file once it's
+    // finalised. Playwright assigns random filenames; we rename to <id>.webm so downstream
+    // conversion has a stable input.
+    const videoHandle = await page.video();
+    await context.close();
+    await browser.close();
+
+    if (videoHandle) {
+      const rawPath = await videoHandle.path();
+      videoPath = path.join(recordingsDir, `${scenario.id}.webm`);
+      // Move/rename. Playwright writes to a randomised path under recordings/.
+      try {
+        if (fs.existsSync(videoPath)) fs.rmSync(videoPath);
+        fs.renameSync(rawPath, videoPath);
+        log(`Saved → ${path.relative(projectRoot, videoPath)}`);
+      } catch (err) {
+        log(`WARNING: could not rename ${rawPath} → ${videoPath}: ${err.message}`);
+        log(`Raw file may still be present at: ${rawPath}`);
+      }
+    } else {
+      log('WARNING: no video handle returned by Playwright — recording lost.');
+    }
+  }
+
+  return { outcome, videoPath };
+}

--- a/scripts/playwright-recorder/package.json
+++ b/scripts/playwright-recorder/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "coralledger-docs-video-recorder",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright-driven demo video recorder for CoralLedger Comply docs. Captures .webm screen recordings of authenticated workflows against staging; pairs with scripts/convert-marketing-videos.sh for .webm -> .mp4 conversion.",
+  "type": "module",
+  "scripts": {
+    "install:browsers": "playwright install chromium",
+    "record:one": "node run.js",
+    "record:all": "node run.js --all"
+  },
+  "dependencies": {
+    "playwright": "^1.48.0"
+  }
+}

--- a/scripts/playwright-recorder/run.js
+++ b/scripts/playwright-recorder/run.js
@@ -1,0 +1,78 @@
+// Per-scenario runner.
+//
+// Usage:
+//   STAGING_TEST_AUTH_SECRET=... node run.js compliance-01
+//   STAGING_TEST_AUTH_SECRET=... node run.js --all
+//
+// Each scenario produces recordings/<id>.webm. Convert the directory to .mp4 with:
+//   ../convert-marketing-videos.sh recordings ../../dist/videos
+
+import { runScenario } from './lib/recorder.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scenariosDir = path.join(__dirname, 'scenarios');
+
+async function listScenarios() {
+  return fs
+    .readdirSync(scenariosDir)
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => f.replace(/\.js$/, ''));
+}
+
+async function loadScenario(id) {
+  const file = path.join(scenariosDir, `${id}.js`);
+  if (!fs.existsSync(file)) {
+    throw new Error(`Scenario '${id}' not found at ${file}.`);
+  }
+  // dynamic import; need file:// URL on Windows
+  const url = 'file://' + file.replace(/\\/g, '/');
+  const mod = await import(url);
+  if (!mod.default || typeof mod.default.record !== 'function') {
+    throw new Error(`Scenario '${id}' must export a default with a record() function.`);
+  }
+  return mod.default;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error('Usage:  node run.js <scenario-id>  |  node run.js --all');
+    console.error('Available scenarios:');
+    for (const id of await listScenarios()) console.error(`  - ${id}`);
+    process.exit(1);
+  }
+
+  let ids;
+  if (args[0] === '--all') {
+    ids = await listScenarios();
+  } else {
+    ids = args;
+  }
+
+  const results = [];
+  for (const id of ids) {
+    const scenario = await loadScenario(id);
+    try {
+      const result = await runScenario(scenario);
+      results.push({ id, ...result });
+    } catch (err) {
+      results.push({ id, outcome: 'failed', error: err.message });
+    }
+  }
+
+  console.log('\n=== Summary ===');
+  for (const r of results) {
+    const status = r.outcome === 'ok' ? 'OK' : 'FAILED';
+    console.log(`  ${status.padEnd(6)} ${r.id}${r.error ? '  — ' + r.error : ''}`);
+  }
+  const anyFailed = results.some((r) => r.outcome !== 'ok');
+  process.exit(anyFailed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/playwright-recorder/scenarios/compliance-01.js
+++ b/scripts/playwright-recorder/scenarios/compliance-01.js
@@ -1,0 +1,63 @@
+// compliance-01: Compliance Score Overview and Grading
+//
+// Target docs page: docs/compliance/compliance-score.mdx
+// CDN target: cdn.coralledger.com/demos/compliance-01.mp4
+// Scope: read-only surface; safe to record against the canonical staging tenant.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'compliance-01',
+  title: 'Compliance — Score Overview and Grading',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating via TestAuth bypass.');
+    await authenticateViaTestAuth(page, { redirectTo: '/dashboard' });
+
+    log('Landed on dashboard. Letting the compliance widget render.');
+    await page.waitForLoadState('networkidle');
+    await wait(2500);
+
+    log('Highlighting the Compliance Weather card on the dashboard.');
+    // Compliance Weather is the canonical compliance-score widget on /client.
+    // Hover gives the viewer a visual cue.
+    const complianceCard = page.locator('[data-testid="compliance-weather"]').first();
+    if (await complianceCard.count() > 0) {
+      await complianceCard.scrollIntoViewIfNeeded();
+      await complianceCard.hover();
+      await wait(2000);
+    } else {
+      log('compliance-weather testid not found, skipping hover.');
+    }
+
+    log('Navigating to the full Compliance Score page.');
+    // Try the explicit Compliance Score page; fall back to the dashboard alone if not
+    // available. The audit found `/compliance` was the canonical compliance surface.
+    await page.goto('https://stg-comply.coralledger.com/compliance', {
+      waitUntil: 'networkidle',
+    });
+    await wait(2500);
+
+    log('Scrolling through the compliance detail sections.');
+    // Slow scroll so the viewer can read the grade breakdown.
+    await page.evaluate(async () => {
+      const totalScroll = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 20;
+      const step = totalScroll / steps;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: step, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    });
+    await wait(1500);
+
+    log('Scrolling back to top for a clean closing frame.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/exports-01.js
+++ b/scripts/playwright-recorder/scenarios/exports-01.js
@@ -1,0 +1,67 @@
+// exports-01: Reports — Export Formats and Download Options
+//
+// Target docs page: docs/reports/index.mdx
+// CDN target: cdn.coralledger.com/demos/exports-01.mp4
+// Scope: read-only navigation of the Reports section showing the available report types
+// and their export formats. Does NOT trigger any actual export download (browser save
+// dialogs would interrupt the recording).
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'exports-01',
+  title: 'Reports — Export Formats and Download Options',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating via TestAuth bypass.');
+    await authenticateViaTestAuth(page, { redirectTo: '/dashboard' });
+
+    await page.waitForLoadState('networkidle');
+    await wait(1500);
+
+    log('Navigating to the Reports landing.');
+    // The /reports landing is the canonical entry to multi-report navigation.
+    await page.goto('https://stg-comply.coralledger.com/reports', {
+      waitUntil: 'networkidle',
+    });
+    await wait(2500);
+
+    log('Scrolling through the Reports section to show available reports.');
+    await page.evaluate(async () => {
+      const totalScroll = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 16;
+      const step = totalScroll / steps;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: step, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    });
+    await wait(1500);
+
+    log('Demonstrating the Cash Flow Report surface — Export CSV button.');
+    await page.goto('https://stg-comply.coralledger.com/reports/cashflow', {
+      waitUntil: 'networkidle',
+    });
+    await wait(2500);
+
+    // Hover the Export CSV button without clicking (clicking triggers a file download
+    // which would interrupt video recording and may bloat the .webm).
+    const exportButton = page.getByRole('button', { name: /export.*csv/i }).first();
+    if (await exportButton.count() > 0) {
+      await exportButton.scrollIntoViewIfNeeded();
+      await exportButton.hover();
+      await wait(2000);
+    } else {
+      log('Export CSV button not found by role/name; skipping hover.');
+    }
+
+    log('Closing on the Cash Flow Report landing.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+
+    log('Recording complete.');
+  },
+};


### PR DESCRIPTION
Infrastructure-only PR. No recordings produced; no docs pages changed.

## What lands

`scripts/playwright-recorder/` — a Node ESM Playwright project that:

- Logs into staging via the same TestAuth bypass the Reef smoke suite uses (`X-TestAuth-Secret` header on `**/api/test-auth/**` routes; default user `ksaconsultantsltd@gmail.com`)
- Records a Chromium 1280x720 session per scenario to `.webm`
- Renames the Playwright-randomised output filename to `<scenario.id>.webm` so downstream conversion has a stable input
- Two proof-of-concept scenarios:
  - `compliance-01` — Compliance Score Overview and Grading (target: `docs/compliance/compliance-score.mdx`)
  - `exports-01` — Reports / Export Formats (target: `docs/reports/index.mdx`)

## How it integrates

- Pairs with the pre-existing `scripts/convert-marketing-videos.sh` for `.webm` → `.mp4` conversion
- The produced `.mp4` files target `cdn.coralledger.com/demos/<id>.mp4` (already where the `DemoVideo` component points)
- The `DemoVideo` component itself was untouched by PR #200 — once a video is hosted, the embed re-introduction is a one-line edit per page

## Out of scope (next steps)

1. `STAGING_TEST_AUTH_SECRET` env var set in the recording machine's shell (founder action)
2. `cdn.coralledger.com` provisioning on Azure Blob + Front Door (founder action)
3. Run the recorder, convert .webm → .mp4, upload to CDN, re-add `<DemoVideo>` embeds
4. 20 remaining scenarios to be added once the proof-of-concept loop is validated end-to-end

## Verification

- All JS files `node --check` parse clean
- `npm install` + `npx playwright install chromium` complete locally
- Recording dry-run blocked on env var (intentional fail-closed per CLAUDE.md secret-handling rule — recorder throws if `STAGING_TEST_AUTH_SECRET` missing)

## Related

- caribdigital/coralledger-docs#150 (DemoVideo broken sitewide; PR #200 stopgapped via callout removal; this PR begins the long-term path)
- caribdigital/coralledger-docs#200 (the stopgap)
- caribdigital/coralledgercomply tests/CoralComply.E2E.Tests/Smoke/SmokeTestBase.cs (auth-pattern source of truth)