### PR TITLE
fix(recorder): correct compliance-01 user/route/selector

### DIFF
--- a/scripts/playwright-recorder/scenarios/compliance-01.js
+++ b/scripts/playwright-recorder/scenarios/compliance-01.js
@@ -14,29 +14,36 @@ export default {
   viewport: { width: 1280, height: 720 },
 
   async record({ page, log }) {
-    log('Authenticating via TestAuth bypass.');
-    await authenticateViaTestAuth(page, { redirectTo: '/dashboard' });
+    // etienne.mckenzie@example.com is the canonical staging BusinessOwner (single-tenant)
+    // — they land directly on /client with a business context, where ComplianceWeather renders.
+    // ksaconsultantsltd@gmail.com is a firm owner with no default client and would hit
+    // "No business selected" on /client.
+    log('Authenticating via TestAuth bypass as etienne.mckenzie@example.com (BusinessOwner).');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/client',
+    });
 
-    log('Landed on dashboard. Letting the compliance widget render.');
+    log('Landed on /client. Letting the dashboard render.');
     await page.waitForLoadState('networkidle');
-    await wait(2500);
+    await wait(3000);
 
-    log('Highlighting the Compliance Weather card on the dashboard.');
-    // Compliance Weather is the canonical compliance-score widget on /client.
-    // Hover gives the viewer a visual cue.
-    const complianceCard = page.locator('[data-testid="compliance-weather"]').first();
+    log('Highlighting the Compliance Weather card.');
+    // ComplianceWeather component renders with class `compliance-weather`; no data-testid yet
+    // (tracked separately in Comply). CSS class selector is the stable surface.
+    const complianceCard = page.locator('.compliance-weather').first();
     if (await complianceCard.count() > 0) {
       await complianceCard.scrollIntoViewIfNeeded();
       await complianceCard.hover();
-      await wait(2000);
+      await wait(2500);
     } else {
-      log('compliance-weather testid not found, skipping hover.');
+      log('WARNING: .compliance-weather not found — user may have no business context.');
     }
 
-    log('Navigating to the full Compliance Score page.');
-    // Try the explicit Compliance Score page; fall back to the dashboard alone if not
-    // available. The audit found `/compliance` was the canonical compliance surface.
-    await page.goto('https://stg-comply.coralledger.com/compliance', {
+    log('Navigating to the full Compliance Intelligence page.');
+    // ClientDashboard's ComplianceWeather "View Details" action navigates here for
+    // non-getting-started users; this is the canonical compliance detail surface.
+    await page.goto('https://stg-comply.coralledger.com/compliance/intelligence', {
       waitUntil: 'networkidle',
     });
     await wait(2500);


### PR DESCRIPTION
## Summary

Verified end-to-end against staging — the original `compliance-01` scenario (added in #201) was authenticating as `ksaconsultantsltd@gmail.com` (Accounting Firm Owner) and landing on `/dashboard`, but `<ComplianceWeather>` actually lives on `/client` (gated on `_currentBusinessId.HasValue`). The `data-testid="compliance-weather"` selector also didn't match — the component renders with the CSS class `.compliance-weather` and has no testid yet.

Net effect of the original scenario: ~30s of dashboard scrolling with no hover callout. With this fix: 1.95MB .webm (up from 1.28MB) including the widget hover + the `/compliance/intelligence` detail page.

## Changes

- Switch user to `etienne.mckenzie@example.com` (canonical staging BusinessOwner — runbook: `docs/operations/STAGING_TEST_USERS.md`)
- Redirect to `/client` (the ComplianceWeather host route)
- Target `.compliance-weather` (CSS class — data-testid follow-up filed separately upstream)
- Navigate to `/compliance/intelligence` for the detail surface (the canonical "View Details" target from `ClientDashboard.razor:85`)

## Test plan

- [x] Recorder ran successfully against `https://stg-comply.coralledger.com` — see `recordings/compliance-01.webm` (1.95MB)
- [x] No "WARNING: .compliance-weather not found" log emitted (proves selector matched + hover ran)
- [x] ffmpeg conversion to `dist/videos/compliance-01.mp4` (1.35MB, libx264 + AAC + faststart)