### PR TITLE
feat(recorder): add 10 batch-2 demo video scenarios

### DIFF
--- a/scripts/playwright-recorder/scenarios/client-management-01.js
+++ b/scripts/playwright-recorder/scenarios/client-management-01.js
@@ -1,0 +1,50 @@
+// client-management-01: Firm Portal — Multi-Client Dashboard
+//
+// Target docs page: docs/firm-portal/index.mdx
+// CDN target: cdn.coralledger.com/demos/client-management-01.mp4
+// Scope: read-only tour of the Firm Portal client roster — shows the multi-client list
+// view that's the firm's daily landing surface.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'client-management-01',
+  title: 'Firm Portal — Multi-Client Dashboard',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as Firm Owner (ksaconsultantsltd@gmail.com).');
+    await authenticateViaTestAuth(page, {
+      email: 'ksaconsultantsltd@gmail.com',
+      redirectTo: '/firm/clients',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Scrolling through the client roster.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 14;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 300));
+      }
+    });
+    await wait(1500);
+
+    log('Hovering the search/filter control if available.');
+    const search = page.getByPlaceholder(/search/i).first();
+    if (await search.count() > 0) {
+      await search.scrollIntoViewIfNeeded();
+      await search.hover();
+      await wait(1800);
+    }
+
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/client-management-02.js
+++ b/scripts/playwright-recorder/scenarios/client-management-02.js
@@ -1,0 +1,55 @@
+// client-management-02: Firm Portal — Adding and Managing Clients
+//
+// Target docs page: docs/firm-portal/index.mdx
+// CDN target: cdn.coralledger.com/demos/client-management-02.mp4
+// Scope: open the firm-portal client onboarding wizard and walk the first step or two,
+// then CANCEL. No real client business is created — staging dataset must not be polluted.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'client-management-02',
+  title: 'Firm Portal — Adding and Managing Clients',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as Firm Owner.');
+    await authenticateViaTestAuth(page, {
+      email: 'ksaconsultantsltd@gmail.com',
+      redirectTo: '/firm/clients/onboard',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3500);
+
+    log('Scrolling the onboarding wizard to surface the form sections.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 14;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 320));
+      }
+    });
+    await wait(1800);
+
+    log('Hovering key onboarding fields (no typing — keeps the form clean).');
+    for (const labelPattern of [/business.*name/i, /trn|tax.*number/i, /address/i, /email/i]) {
+      const field = page.getByLabel(labelPattern).first();
+      if (await field.count() > 0) {
+        await field.scrollIntoViewIfNeeded();
+        await field.hover();
+        await wait(1100);
+      }
+    }
+
+    log('Navigating back to /firm/clients without submitting.');
+    await page.goto('https://stg-comply.coralledger.com/firm/clients', {
+      waitUntil: 'networkidle',
+    });
+    await wait(2000);
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/compliance-02.js
+++ b/scripts/playwright-recorder/scenarios/compliance-02.js
@@ -1,0 +1,56 @@
+// compliance-02: Compliance — Improving Your Score
+//
+// Target docs page: docs/compliance/compliance-score.mdx
+// CDN target: cdn.coralledger.com/demos/compliance-02.mp4
+// Scope: read-only navigation of the Compliance Intelligence detail page, focused on the
+// recommendations / action-items section that drives score improvement.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'compliance-02',
+  title: 'Compliance — Improving Your Score',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as BusinessOwner.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/compliance/intelligence',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Scrolling slowly through the intelligence page to surface recommendations.');
+    // Slower step pace than compliance-01 so the viewer can read the action items.
+    await page.evaluate(async () => {
+      const totalScroll = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 24;
+      const step = totalScroll / steps;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: step, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 350));
+      }
+    });
+    await wait(2000);
+
+    log('Highlighting the score-improvement section if present.');
+    const recommendations = page.locator('[data-testid*="recommend"], .compliance-recommendation, [class*="recommendation"]').first();
+    if (await recommendations.count() > 0) {
+      await recommendations.scrollIntoViewIfNeeded();
+      await recommendations.hover();
+      await wait(2500);
+    } else {
+      log('No recommendations panel matched; continuing.');
+    }
+
+    log('Returning to top for a clean closing frame.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/mobile-01.js
+++ b/scripts/playwright-recorder/scenarios/mobile-01.js
@@ -1,0 +1,70 @@
+// mobile-01: Mobile — Responsive Interface on Phone and Tablet
+//
+// Target docs page: docs/getting-started/mobile.mdx
+// CDN target: cdn.coralledger.com/demos/mobile-01.mp4
+// Scope: drive the dashboard at a mobile viewport (iPhone 12 Pro size) to demonstrate
+// the responsive layout. Different aspect ratio from the standard 1280x720 — viewers
+// can clearly tell this is mobile.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'mobile-01',
+  title: 'Mobile — Responsive Interface on Phone and Tablet',
+  viewport: { width: 390, height: 844 },
+
+  async record({ page, log }) {
+    log('Authenticating as BusinessOwner with mobile viewport.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/client',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Tapping the hamburger / menu button if present.');
+    const menuBtn = page.locator('button[aria-label*="menu" i], button[class*="menu" i], .mud-appbar button').first();
+    if (await menuBtn.count() > 0) {
+      await menuBtn.hover();
+      await wait(1200);
+      await menuBtn.click({ force: true });
+      await wait(2000);
+
+      // Close it again to keep the demo clean.
+      await menuBtn.click({ force: true });
+      await wait(1200);
+    }
+
+    log('Scrolling the dashboard at mobile width.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 16;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 280));
+      }
+    });
+    await wait(1500);
+
+    log('Navigating to /transactions at mobile width to show table responsiveness.');
+    await page.goto('https://stg-comply.coralledger.com/transactions', {
+      waitUntil: 'networkidle',
+    });
+    await wait(2500);
+
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 12;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 280));
+      }
+    });
+    await wait(1500);
+
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/performance-01.js
+++ b/scripts/playwright-recorder/scenarios/performance-01.js
@@ -1,0 +1,46 @@
+// performance-01: Performance — Fast Load Times and Responsive UI
+//
+// Target docs page: docs/getting-started/performance.mdx
+// CDN target: cdn.coralledger.com/demos/performance-01.mp4
+// Scope: a brisk navigation tour across major routes — dashboard → transactions →
+// vatreturns → reports → compliance — to convey responsive snappiness. Each page is
+// loaded with `networkidle` so any latency is genuine.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'performance-01',
+  title: 'Performance — Fast Load Times and Responsive UI',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as BusinessOwner.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/client',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(2500);
+
+    const tour = [
+      { path: '/transactions', label: 'Transactions list' },
+      { path: '/vatreturns', label: 'VAT Returns list' },
+      { path: '/reports', label: 'Reports landing' },
+      { path: '/compliance/intelligence', label: 'Compliance Intelligence' },
+      { path: '/client', label: 'Back to client dashboard' },
+    ];
+
+    for (const step of tour) {
+      log(`Navigating to ${step.path} — ${step.label}.`);
+      await page.goto(`https://stg-comply.coralledger.com${step.path}`, {
+        waitUntil: 'networkidle',
+      });
+      await wait(1800);
+    }
+
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/registration-01.js
+++ b/scripts/playwright-recorder/scenarios/registration-01.js
@@ -1,0 +1,48 @@
+// registration-01: Account Registration — Sign-Up Form
+//
+// Target docs page: docs/getting-started/create-account.mdx
+// CDN target: cdn.coralledger.com/demos/registration-01.mp4
+// Scope: navigate to the public sign-up form, hover the fields, scroll. NEVER fills or
+// submits — staging dataset must not gain a "Robbie tested the docs recorder" account.
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'registration-01',
+  title: 'Account Registration — Sign-Up Form',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Navigating to the public sign-up form (no auth).');
+    await page.goto('https://stg-comply.coralledger.com/Identity/Account/Register', {
+      waitUntil: 'networkidle',
+    });
+    await wait(3000);
+
+    log('Hovering each sign-up field in turn.');
+    for (const labelPattern of [/email/i, /^password/i, /confirm.*password/i, /terms/i]) {
+      const field = page.getByLabel(labelPattern).first();
+      if (await field.count() > 0) {
+        await field.scrollIntoViewIfNeeded();
+        await field.hover();
+        await wait(1300);
+      }
+    }
+
+    log('Scrolling through the rest of the form (Turnstile / consent / submit area).');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 12;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 280));
+      }
+    });
+    await wait(1500);
+
+    log('Returning to top — never clicks Register, never submits anything.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/share-links-01.js
+++ b/scripts/playwright-recorder/scenarios/share-links-01.js
@@ -1,0 +1,66 @@
+// share-links-01: Shared Reports — Creating and Managing Secure Share Links
+//
+// Target docs page: docs/reports/shared-reports.mdx
+// CDN target: cdn.coralledger.com/demos/share-links-01.mp4
+// Scope: navigate to the shared-reports surface, show the create-link UI if available.
+// Does NOT actually create a share link.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'share-links-01',
+  title: 'Shared Reports — Creating and Managing Secure Share Links',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    // NOTE: /reports/shared/{ShareToken} is the public recipient view (requires a token).
+    // There's no "manage share links" landing page — sharing originates from individual
+    // report surfaces. Drive from /reports/cashflow which has a Share button.
+    log('Authenticating as BusinessOwner.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/reports/cashflow',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Scrolling through the report to surface the share affordance.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 12;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 300));
+      }
+    });
+    await wait(1500);
+
+    log('Locating a Create Share Link button (best-effort).');
+    const createBtn = page.getByRole('button', { name: /create.*(share|link)|new.*(share|link)|share/i }).first();
+    if (await createBtn.count() > 0) {
+      await createBtn.scrollIntoViewIfNeeded();
+      await createBtn.hover();
+      await wait(2000);
+      await createBtn.click({ force: true });
+      await wait(2500);
+
+      log('Closing the create-link dialog without committing.');
+      const cancelBtn = page.getByRole('button', { name: /cancel|close|discard/i }).first();
+      if (await cancelBtn.count() > 0) {
+        await cancelBtn.click({ force: true });
+      } else {
+        await page.keyboard.press('Escape');
+      }
+      await wait(1200);
+    } else {
+      log('No Create Share Link control matched.');
+    }
+
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/transactions-01.js
+++ b/scripts/playwright-recorder/scenarios/transactions-01.js
@@ -1,0 +1,70 @@
+// transactions-01: Transactions — Quick Entry and Advanced Mode
+//
+// Target docs page: docs/transactions/manual-entry.mdx
+// CDN target: cdn.coralledger.com/demos/transactions-01.mp4
+// Scope: open the Add Transaction dialog, hover fields, then CANCEL (no real transaction
+// created — the staging dataset must not be polluted).
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'transactions-01',
+  title: 'Transactions — Quick Entry and Advanced Mode',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as BusinessOwner.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/transactions',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Locating the Add Transaction (or similar) primary action.');
+    const addButton = page.getByRole('button', { name: /add.*(transaction|entry)|new.*transaction|\+\s*transaction/i }).first();
+    if (await addButton.count() > 0) {
+      await addButton.scrollIntoViewIfNeeded();
+      await addButton.hover();
+      await wait(1500);
+      await addButton.click({ force: true });
+      log('Dialog opened — letting fields render.');
+      await wait(2500);
+
+      // Hover a few key fields without typing — keeps the recording clean and avoids any
+      // accidental form submission.
+      for (const labelPattern of [/amount/i, /description/i, /vat.*(rate|category)/i, /date/i]) {
+        const field = page.getByLabel(labelPattern).first();
+        if (await field.count() > 0) {
+          await field.hover();
+          await wait(900);
+        }
+      }
+
+      log('Closing the dialog without saving.');
+      const cancelBtn = page.getByRole('button', { name: /cancel|close|discard/i }).first();
+      if (await cancelBtn.count() > 0) {
+        await cancelBtn.click({ force: true });
+      } else {
+        await page.keyboard.press('Escape');
+      }
+      await wait(1500);
+    } else {
+      log('Add Transaction button not found; scrolling the transactions list instead.');
+      await page.evaluate(async () => {
+        const total = document.documentElement.scrollHeight - window.innerHeight;
+        const steps = 10;
+        for (let i = 0; i < steps; i++) {
+          window.scrollBy({ top: total / steps, behavior: 'smooth' });
+          await new Promise((r) => setTimeout(r, 300));
+        }
+      });
+      await wait(1500);
+    }
+
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/transactions-03.js
+++ b/scripts/playwright-recorder/scenarios/transactions-03.js
@@ -1,0 +1,57 @@
+// transactions-03: Transactions — CSV Import and Column Mapping
+//
+// Target docs page: docs/transactions/import-csv.mdx
+// CDN target: cdn.coralledger.com/demos/transactions-03.mp4
+// Scope: navigate to the CSV import landing, show the upload UI + format requirements. No
+// actual file upload occurs — clicking the upload control would open a native file dialog
+// that interrupts recording.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'transactions-03',
+  title: 'Transactions — CSV Import and Column Mapping',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as BusinessOwner.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/transactions/import',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Letting the import page settle, then scrolling through the format guidance.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 14;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 320));
+      }
+    });
+    await wait(1500);
+
+    log('Highlighting the visible upload zone — skipping the underlying hidden file input.');
+    // MudFileUpload renders a visible MudPaper/MudButton wrapper around a hidden
+    // <input type="file">. Target the wrapper (visible) and avoid the hidden input.
+    const dropZone = page.locator('.mud-file-upload, [class*="upload-zone"]:not(input)').first();
+    if (await dropZone.count() > 0) {
+      await dropZone.scrollIntoViewIfNeeded();
+      await dropZone.hover();
+      await wait(2500);
+    } else {
+      log('No visible upload-zone wrapper matched — leaving the page settled.');
+    }
+
+    log('Returning to top.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(1500);
+
+    log('Recording complete.');
+  },
+};

--- a/scripts/playwright-recorder/scenarios/vat-returns-01.js
+++ b/scripts/playwright-recorder/scenarios/vat-returns-01.js
@@ -1,0 +1,69 @@
+// vat-returns-01: VAT Returns — Selecting a Period and Reviewing Summary
+//
+// Target docs page: docs/vat-returns/generate-return.mdx
+// CDN target: cdn.coralledger.com/demos/vat-returns-01.mp4
+// Scope: open the Create VAT Return dialog, demonstrate period + year selection, CANCEL.
+// No return is created — staging must not be polluted.
+
+import { authenticateViaTestAuth } from '../lib/auth.js';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export default {
+  id: 'vat-returns-01',
+  title: 'VAT Returns — Selecting a Period and Reviewing Summary',
+  viewport: { width: 1280, height: 720 },
+
+  async record({ page, log }) {
+    log('Authenticating as BusinessOwner.');
+    await authenticateViaTestAuth(page, {
+      email: 'etienne.mckenzie@example.com',
+      redirectTo: '/vatreturns',
+    });
+
+    await page.waitForLoadState('networkidle');
+    await wait(3000);
+
+    log('Locating the Create / New VAT Return primary action.');
+    const createButton = page.getByRole('button', { name: /create.*(return|vat)|new.*(return|vat)|\+\s*return/i }).first();
+    if (await createButton.count() > 0) {
+      await createButton.scrollIntoViewIfNeeded();
+      await createButton.hover();
+      await wait(1500);
+      await createButton.click({ force: true });
+      log('Create-return dialog opened.');
+      await wait(2500);
+
+      // Hover the period dropdown to surface the calendar/period UI without committing.
+      for (const labelPattern of [/period/i, /month/i, /year/i, /quarter/i]) {
+        const field = page.getByLabel(labelPattern).first();
+        if (await field.count() > 0) {
+          await field.hover();
+          await wait(900);
+        }
+      }
+
+      log('Closing the dialog without creating a return.');
+      const cancelBtn = page.getByRole('button', { name: /cancel|close|discard/i }).first();
+      if (await cancelBtn.count() > 0) {
+        await cancelBtn.click({ force: true });
+      } else {
+        await page.keyboard.press('Escape');
+      }
+      await wait(1500);
+    } else {
+      log('Create return button not found; scrolling the returns list.');
+      await page.evaluate(async () => {
+        const total = document.documentElement.scrollHeight - window.innerHeight;
+        const steps = 10;
+        for (let i = 0; i < steps; i++) {
+          window.scrollBy({ top: total / steps, behavior: 'smooth' });
+          await new Promise((r) => setTimeout(r, 300));
+        }
+      });
+      await wait(1500);
+    }
+
+    log('Recording complete.');
+  },
+};


### PR DESCRIPTION
## Summary

Brings the recorder from 2 → 12 scenarios — the first cohort that can be embedded as `<DemoVideo>` once `cdn.coralledger.com` is provisioned (long-term path for #150). All 12 scenarios verified end-to-end against staging (`node run.js --all` → 12/12 OK).

| Scenario | User | Route | Notes |
|---|---|---|---|
| `compliance-02` | etienne (BO) | `/compliance/intelligence` | slower scroll than `-01` to surface recommendations |
| `transactions-01` | etienne (BO) | `/transactions` | opens Add dialog, hovers fields, cancels |
| `transactions-03` | etienne (BO) | `/transactions/import` | scrolls + hovers `.mud-file-upload` wrapper (skip hidden input) |
| `vat-returns-01` | etienne (BO) | `/vatreturns` | opens Create Return dialog, cancels |
| `share-links-01` | etienne (BO) | `/reports/cashflow` | best-effort share affordance (no manage page exists yet) |
| `mobile-01` | etienne (BO) | `/client` @ 390x844 | mobile viewport tour |
| `performance-01` | etienne (BO) | 5-route tour | shows snappy navigation |
| `client-management-01` | ksaconsultantsltd (FO) | `/firm/clients` | read-only roster scroll |
| `client-management-02` | ksaconsultantsltd (FO) | `/firm/clients/onboard` | wizard fields hover, no submit |
| `registration-01` | none (public) | `/Identity/Account/Register` | hovers fields, NEVER submits |

## Safety guardrails

- Authenticated scenarios use the documented staging users — see `docs/operations/STAGING_TEST_USERS.md` in the Comply repo.
- **NO destructive actions**: dialogs cancelled, forms never submitted, uploads never triggered, share links never created.
- Read-only routes only — staging dataset stays clean.

## Deferred (10 of the original 22)

Need data-state or judgment calls; will be follow-ups: `transactions-02`, `vat-returns-02/03/04`, `rate-transition-01`, `multi-tenant-01`, `client-management-03`, `registration-02/03/04`.

## Test plan

- [x] `node run.js --all` against `stg-comply.coralledger.com` → 12/12 OK
- [x] ffmpeg conversion to `dist/videos/*.mp4` — all 12 produce valid H.264+AAC+faststart MP4s (306KB–1.5MB, 10s–39s)
- [ ] Spot-check each `.mp4` before re-adding `<DemoVideo>` embeds (Robbie)
- [ ] `cdn.coralledger.com` provisioning + upload (founder action)