### PR TITLE
fix(recorder): scenario corrections + final-frame screenshots + 5s outro dwell

### DIFF
--- a/scripts/playwright-recorder/lib/recorder.js
+++ b/scripts/playwright-recorder/lib/recorder.js
@@ -100,6 +100,28 @@ export async function runScenario(scenario) {
       log(`ERROR: ${err.message}`);
       throw err;
     } finally {
+      // Capture a final-frame full-page screenshot for visual QA. The recording's "OK" exit
+      // code only proves the script didn't throw — not that the destination rendered. The
+      // screenshot is the truth source: if it shows a blank page / error / login redirect,
+      // the .mp4 is broken regardless of what the run.js summary says.
+      try {
+        const screenshotPath = path.join(recordingsDir, `${scenario.id}_final.png`);
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+        log(`Final-frame screenshot → ${path.relative(projectRoot, screenshotPath)}`);
+      } catch (err) {
+        log(`WARNING: could not capture final-frame screenshot: ${err.message}`);
+      }
+
+      // Final dwell: hold the closing frame in-recording so the viewer has time to read
+      // the resulting state. Configurable per scenario; default 5s gives every scenario a
+      // breathing-room outro and is the main lever for pushing recordings past the 20s
+      // minimum. Skip with `scenario.finalDwellMs = 0` for explicitly short demos.
+      const finalDwellMs = scenario.finalDwellMs ?? 5000;
+      if (finalDwellMs > 0) {
+        log(`Final dwell ${finalDwellMs}ms before close.`);
+        await page.waitForTimeout(finalDwellMs);
+      }
+
       const videoHandle = await page.video();
       await context.close();
 

--- a/scripts/playwright-recorder/scenarios/client-management-01.js
+++ b/scripts/playwright-recorder/scenarios/client-management-01.js
@@ -28,26 +28,40 @@ export default {
     await page.goto(`${BASE}/firm/clients`, { waitUntil: 'networkidle' });
     await wait(2500);
 
-    log('Scrolling through the client roster.');
+    log('Dwelling on the KPI strip at the top.');
+    // The page has Total Clients / Active / VAT Registered / Added This Month KPI cards.
+    // Use a stable text-based locator targeting one of them, hover for emphasis, dwell.
+    const kpiHeadline = page.getByText(/total clients/i).first();
+    if (await kpiHeadline.count() > 0) {
+      await kpiHeadline.scrollIntoViewIfNeeded().catch(() => {});
+      await kpiHeadline.hover().catch(() => {});
+      await wait(2500);
+    } else {
+      await wait(2500);
+    }
+
+    log('Scrolling slowly through the client roster.');
     await page.evaluate(async () => {
       const total = document.documentElement.scrollHeight - window.innerHeight;
-      const steps = 14;
+      const steps = 18;
       for (let i = 0; i < steps; i++) {
         window.scrollBy({ top: total / steps, behavior: 'smooth' });
-        await new Promise((r) => setTimeout(r, 300));
+        await new Promise((r) => setTimeout(r, 380));
       }
     });
-    await wait(1500);
+    await wait(2000);
 
+    log('Hovering the search/filter control.');
     const search = page.getByPlaceholder(/search/i).first();
     if (await search.count() > 0) {
       await search.scrollIntoViewIfNeeded();
       await search.hover();
-      await wait(1500);
+      await wait(2500);
     }
 
+    log('Returning to top.');
     await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
-    await wait(1200);
+    await wait(2500);
     log('Recording complete.');
   },
 };

--- a/scripts/playwright-recorder/scenarios/client-management-02.js
+++ b/scripts/playwright-recorder/scenarios/client-management-02.js
@@ -2,7 +2,10 @@
 //
 // Target docs page: docs/firm-portal/index.mdx
 // CDN target: cdn.coralledger.com/demos/client-management-02.mp4
-// Scope: walk through onboarding wizard, CANCEL — no client business created.
+// Flow: start at /firm/clients (the rich list view), hover + click "+ Add Client" which
+// navigates to /firm/clients/onboard, dwell on the onboarding wizard. End there — don't
+// navigate back to the list (that would make the wizard be the BULK of the video while
+// the final frame is the list, mismatching the docs page).
 
 import { authenticateViaTestAuth } from '../lib/auth.js';
 
@@ -18,41 +21,59 @@ export default {
     log('Authenticating as Firm Owner — warmup.');
     await authenticateViaTestAuth(page, {
       email: 'ksaconsultantsltd@gmail.com',
-      redirectTo: '/firm/clients/onboard',
+      redirectTo: '/firm/clients',
     });
     await page.waitForLoadState('networkidle');
     await wait(3000);
   },
 
   async record({ page, log }) {
-    log('Navigating to /firm/clients/onboard with warm session.');
-    await page.goto(`${BASE}/firm/clients/onboard`, { waitUntil: 'networkidle' });
-    await wait(3000);
+    log('Starting on /firm/clients (client list with KPI cards).');
+    await page.goto(`${BASE}/firm/clients`, { waitUntil: 'networkidle' });
+    await wait(3500);
 
-    log('Scrolling the onboarding wizard.');
+    log('Hovering the "+ Add Client" primary action.');
+    const addBtn = page.getByRole('button', { name: /add.*client|invite.*client/i }).first();
+    if (await addBtn.count() > 0) {
+      await addBtn.scrollIntoViewIfNeeded();
+      await addBtn.hover();
+      await wait(2500);
+
+      log('Clicking Add Client → /firm/clients/onboard.');
+      await addBtn.click({ force: true });
+      await page.waitForLoadState('networkidle');
+      await wait(3500);
+    } else {
+      // Fallback: direct nav.
+      log('Add Client button not found by name; navigating directly to /firm/clients/onboard.');
+      await page.goto(`${BASE}/firm/clients/onboard`, { waitUntil: 'networkidle' });
+      await wait(3500);
+    }
+
+    log('Scrolling through the onboarding wizard form.');
     await page.evaluate(async () => {
       const total = document.documentElement.scrollHeight - window.innerHeight;
-      const steps = 14;
+      const steps = 18;
       for (let i = 0; i < steps; i++) {
         window.scrollBy({ top: total / steps, behavior: 'smooth' });
-        await new Promise((r) => setTimeout(r, 320));
+        await new Promise((r) => setTimeout(r, 380));
       }
     });
-    await wait(1500);
+    await wait(2000);
 
-    log('Hovering key onboarding fields (no typing).');
-    for (const labelPattern of [/business.*name/i, /trn|tax.*number/i, /address/i, /email/i]) {
+    log('Hovering wizard fields one at a time (no typing).');
+    for (const labelPattern of [/business.*name|company.*name/i, /trn|tax.*number/i, /address|street/i, /email|contact/i, /phone/i]) {
       const field = page.getByLabel(labelPattern).first();
       if (await field.count() > 0) {
         await field.scrollIntoViewIfNeeded();
         await field.hover();
-        await wait(1100);
+        await wait(1400);
       }
     }
 
-    log('Navigating back to /firm/clients without submitting.');
-    await page.goto(`${BASE}/firm/clients`, { waitUntil: 'networkidle' });
-    await wait(1800);
-    log('Recording complete.');
+    log('Final dwell on the onboarding wizard.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(3500);
+    log('Recording complete (wizard remains on-screen — never submitted).');
   },
 };

--- a/scripts/playwright-recorder/scenarios/exports-01.js
+++ b/scripts/playwright-recorder/scenarios/exports-01.js
@@ -2,6 +2,9 @@
 //
 // Target docs page: docs/reports/index.mdx
 // CDN target: cdn.coralledger.com/demos/exports-01.mp4
+// Scope: focus on the Cash Flow Report surface (which has Export CSV button + real data
+// for ksaconsultantsltd's tagged client context). Avoids the /reports landing for
+// firm-side users where the page is sparse.
 
 import { authenticateViaTestAuth } from '../lib/auth.js';
 
@@ -14,41 +17,39 @@ export default {
   viewport: { width: 1280, height: 720 },
 
   async warmup({ page, log }) {
-    log('Authenticating — warmup, no recording yet.');
-    await authenticateViaTestAuth(page, { redirectTo: '/reports' });
+    log('Authenticating (default firm user with client context) — warmup.');
+    await authenticateViaTestAuth(page, { redirectTo: '/reports/cashflow' });
     await page.waitForLoadState('networkidle');
-    await wait(2500);
+    await wait(3000);
   },
 
   async record({ page, log }) {
-    log('Navigating to /reports with warm session.');
-    await page.goto(`${BASE}/reports`, { waitUntil: 'networkidle' });
-    await wait(2000);
-
-    log('Scrolling through the Reports landing.');
-    await page.evaluate(async () => {
-      const totalScroll = document.documentElement.scrollHeight - window.innerHeight;
-      const steps = 16;
-      for (let i = 0; i < steps; i++) {
-        window.scrollBy({ top: totalScroll / steps, behavior: 'smooth' });
-        await new Promise((r) => setTimeout(r, 250));
-      }
-    });
-    await wait(1500);
-
-    log('Navigating to Cash Flow Report for the Export CSV demo.');
+    log('Navigating directly to /reports/cashflow with warm session.');
     await page.goto(`${BASE}/reports/cashflow`, { waitUntil: 'networkidle' });
-    await wait(2500);
+    await wait(3500);
 
+    log('Hovering the Export CSV button (top-right primary action).');
     const exportButton = page.getByRole('button', { name: /export.*csv/i }).first();
     if (await exportButton.count() > 0) {
       await exportButton.scrollIntoViewIfNeeded();
       await exportButton.hover();
-      await wait(2000);
+      await wait(3000);
     }
 
+    log('Slow scroll through the cash flow timeline + obligations + monthly summary.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 20;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 400));
+      }
+    });
+    await wait(3000);
+
+    log('Returning to top — Export CSV remains in frame on the closing dwell.');
     await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
-    await wait(1200);
+    await wait(4000);
     log('Recording complete.');
   },
 };

--- a/scripts/playwright-recorder/scenarios/registration-01.js
+++ b/scripts/playwright-recorder/scenarios/registration-01.js
@@ -18,33 +18,36 @@ export default {
   // No warmup — registration page is public, no session needed.
 
   async record({ page, log }) {
+    // Canonical sign-up route is /Account/Register (NOT /Identity/Account/Register).
+    // Use `domcontentloaded` instead of `networkidle` — the Turnstile widget keeps the
+    // network in a not-idle state indefinitely, so `networkidle` times out.
     log('Navigating to the public sign-up form.');
-    await page.goto(`${BASE}/Identity/Account/Register`, { waitUntil: 'networkidle' });
-    await wait(2500);
+    await page.goto(`${BASE}/Account/Register`, { waitUntil: 'domcontentloaded' });
+    await wait(4000);
 
     log('Hovering each sign-up field in turn.');
-    for (const labelPattern of [/email/i, /^password/i, /confirm.*password/i, /terms/i]) {
+    for (const labelPattern of [/email/i, /^password/i, /confirm.*password/i, /first.*name/i, /last.*name/i, /terms/i]) {
       const field = page.getByLabel(labelPattern).first();
       if (await field.count() > 0) {
         await field.scrollIntoViewIfNeeded();
         await field.hover();
-        await wait(1300);
+        await wait(1800);
       }
     }
 
-    log('Scrolling through the rest of the form.');
+    log('Scrolling slowly through the rest of the form.');
     await page.evaluate(async () => {
       const total = document.documentElement.scrollHeight - window.innerHeight;
-      const steps = 12;
+      const steps = 16;
       for (let i = 0; i < steps; i++) {
         window.scrollBy({ top: total / steps, behavior: 'smooth' });
-        await new Promise((r) => setTimeout(r, 280));
+        await new Promise((r) => setTimeout(r, 420));
       }
     });
-    await wait(1500);
+    await wait(2500);
 
     await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
-    await wait(1200);
+    await wait(3000);
     log('Recording complete — never clicked Register.');
   },
 };

--- a/scripts/playwright-recorder/scenarios/share-links-01.js
+++ b/scripts/playwright-recorder/scenarios/share-links-01.js
@@ -2,8 +2,9 @@
 //
 // Target docs page: docs/reports/shared-reports.mdx
 // CDN target: cdn.coralledger.com/demos/share-links-01.mp4
-// NOTE: /reports/shared/{ShareToken} is the public recipient view (requires a token).
-// Drive from /reports/cashflow which has a Share affordance.
+// Surface: the "Manage Shared Links" button on /vatreturns (VATReturns.razor:125 calls
+// OpenManageSharedLinksDialog → opens a real dialog). The Cash Flow Report surface has
+// no share affordance, so drive from /vatreturns instead.
 
 import { authenticateViaTestAuth } from '../lib/auth.js';
 
@@ -16,50 +17,57 @@ export default {
   viewport: { width: 1280, height: 720 },
 
   async warmup({ page, log }) {
-    log('Authenticating as etienne — warmup.');
-    await authenticateViaTestAuth(page, {
-      email: 'etienne.mckenzie@example.com',
-      redirectTo: '/reports/cashflow',
-    });
+    log('Authenticating (default firm user) — warmup.');
+    await authenticateViaTestAuth(page, { redirectTo: '/vatreturns' });
     await page.waitForLoadState('networkidle');
-    await wait(2500);
+    await wait(3000);
   },
 
   async record({ page, log }) {
-    log('Navigating to /reports/cashflow with warm session.');
-    await page.goto(`${BASE}/reports/cashflow`, { waitUntil: 'networkidle' });
-    await wait(2500);
+    log('Navigating to /vatreturns with warm session.');
+    await page.goto(`${BASE}/vatreturns`, { waitUntil: 'networkidle' });
+    await wait(3500);
 
-    log('Scrolling through the report.');
-    await page.evaluate(async () => {
-      const total = document.documentElement.scrollHeight - window.innerHeight;
-      const steps = 12;
-      for (let i = 0; i < steps; i++) {
-        window.scrollBy({ top: total / steps, behavior: 'smooth' });
-        await new Promise((r) => setTimeout(r, 300));
-      }
-    });
-    await wait(1500);
-
-    const shareBtn = page.getByRole('button', { name: /share/i }).first();
+    log('Locating "Manage Shared Links" action button.');
+    const shareBtn = page.getByRole('button', { name: /manage.*shared.*link|shared.*link/i }).first();
     if (await shareBtn.count() > 0) {
       await shareBtn.scrollIntoViewIfNeeded();
       await shareBtn.hover();
-      await wait(1800);
-      await shareBtn.click({ force: true });
       await wait(2500);
+      await shareBtn.click({ force: true });
 
-      const cancelBtn = page.getByRole('button', { name: /cancel|close|discard/i }).first();
+      log('Manage Shared Links dialog opened — dwelling.');
+      await wait(5000);
+
+      // Optional: scroll within the dialog if it has content.
+      const dialog = page.locator('.mud-dialog').first();
+      if (await dialog.count() > 0) {
+        await dialog.hover();
+        await wait(2000);
+      }
+
+      log('Closing the dialog without changes.');
+      const cancelBtn = page.getByRole('button', { name: /cancel|close|done/i }).first();
       if (await cancelBtn.count() > 0) {
         await cancelBtn.click({ force: true });
       } else {
         await page.keyboard.press('Escape');
       }
-      await wait(1200);
+      await wait(2500);
+    } else {
+      log('Manage Shared Links button not found — scrolling /vatreturns as fallback.');
+      await page.evaluate(async () => {
+        const total = document.documentElement.scrollHeight - window.innerHeight;
+        for (let i = 0; i < 14; i++) {
+          window.scrollBy({ top: total / 14, behavior: 'smooth' });
+          await new Promise((r) => setTimeout(r, 380));
+        }
+      });
+      await wait(2500);
     }
 
-    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
-    await wait(1200);
+    log('Final dwell on the page.');
+    await wait(3000);
     log('Recording complete.');
   },
 };

--- a/scripts/playwright-recorder/scenarios/transactions-01.js
+++ b/scripts/playwright-recorder/scenarios/transactions-01.js
@@ -2,7 +2,9 @@
 //
 // Target docs page: docs/transactions/manual-entry.mdx
 // CDN target: cdn.coralledger.com/demos/transactions-01.mp4
-// Scope: open Add Transaction dialog, hover fields, then CANCEL — no real txn created.
+// Scope: drive the canonical manual-entry form at /vat/entry (the destination the
+// "+ Add" toolbar button on /transactions links to). Hover fields, scroll through
+// advanced sections, NEVER submit.
 
 import { authenticateViaTestAuth } from '../lib/auth.js';
 
@@ -15,57 +17,44 @@ export default {
   viewport: { width: 1280, height: 720 },
 
   async warmup({ page, log }) {
-    log('Authenticating as etienne (BusinessOwner) — warmup.');
+    log('Authenticating as etienne — warmup at /vat/entry.');
     await authenticateViaTestAuth(page, {
       email: 'etienne.mckenzie@example.com',
-      redirectTo: '/transactions',
+      redirectTo: '/vat/entry',
     });
     await page.waitForLoadState('networkidle');
-    await wait(2500);
+    await wait(3000);
   },
 
   async record({ page, log }) {
-    log('Navigating to /transactions with warm session.');
-    await page.goto(`${BASE}/transactions`, { waitUntil: 'networkidle' });
-    await wait(2500);
+    log('Navigating to /vat/entry with warm session.');
+    await page.goto(`${BASE}/vat/entry`, { waitUntil: 'networkidle' });
+    await wait(3500);
 
-    const addButton = page.getByRole('button', { name: /add.*(transaction|entry)|new.*transaction|\+\s*transaction/i }).first();
-    if (await addButton.count() > 0) {
-      await addButton.scrollIntoViewIfNeeded();
-      await addButton.hover();
-      await wait(1200);
-      await addButton.click({ force: true });
-      log('Dialog opened.');
-      await wait(2500);
-
-      for (const labelPattern of [/amount/i, /description/i, /vat.*(rate|category)/i, /date/i]) {
-        const field = page.getByLabel(labelPattern).first();
-        if (await field.count() > 0) {
-          await field.hover();
-          await wait(900);
-        }
+    log('Hovering each entry field in turn (no typing).');
+    for (const labelPattern of [/date|tax.*point/i, /^description|reference/i, /amount|gross|net/i, /vat.*(rate|category)/i, /supplier|vendor|customer/i, /category|classification/i]) {
+      const field = page.getByLabel(labelPattern).first();
+      if (await field.count() > 0) {
+        await field.scrollIntoViewIfNeeded();
+        await field.hover();
+        await wait(1800);
       }
-
-      log('Closing the dialog without saving.');
-      const cancelBtn = page.getByRole('button', { name: /cancel|close|discard/i }).first();
-      if (await cancelBtn.count() > 0) {
-        await cancelBtn.click({ force: true });
-      } else {
-        await page.keyboard.press('Escape');
-      }
-      await wait(1500);
-    } else {
-      log('Add Transaction button not found — scrolling the list instead.');
-      await page.evaluate(async () => {
-        const total = document.documentElement.scrollHeight - window.innerHeight;
-        for (let i = 0; i < 10; i++) {
-          window.scrollBy({ top: total / 10, behavior: 'smooth' });
-          await new Promise((r) => setTimeout(r, 300));
-        }
-      });
-      await wait(1500);
     }
 
-    log('Recording complete.');
+    log('Scrolling slowly through the form to reveal advanced sections.');
+    await page.evaluate(async () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const steps = 18;
+      for (let i = 0; i < steps; i++) {
+        window.scrollBy({ top: total / steps, behavior: 'smooth' });
+        await new Promise((r) => setTimeout(r, 380));
+      }
+    });
+    await wait(2500);
+
+    log('Returning to top — final dwell on the entry form.');
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }));
+    await wait(2500);
+    log('Recording complete — form was never submitted.');
   },
 };

--- a/scripts/playwright-recorder/scenarios/vat-returns-01.js
+++ b/scripts/playwright-recorder/scenarios/vat-returns-01.js
@@ -29,22 +29,27 @@ export default {
     await page.goto(`${BASE}/vatreturns`, { waitUntil: 'networkidle' });
     await wait(2500);
 
-    const createButton = page.getByRole('button', { name: /create.*(return|vat)|new.*(return|vat)|\+\s*return/i }).first();
+    // The toolbar primary action is labeled "New Return" (icon prefix in the visual). The
+    // accessibility name doesn't include the icon, so match plain "New Return" / "Create Return".
+    const createButton = page.getByRole('button', { name: /^new\s+return$|^create\s+return$|create\s+vat\s+return|new\s+vat\s+return/i }).first();
     if (await createButton.count() > 0) {
       await createButton.scrollIntoViewIfNeeded();
       await createButton.hover();
-      await wait(1200);
+      await wait(2000);
       await createButton.click({ force: true });
-      log('Create-return dialog opened.');
-      await wait(2500);
+      log('Create-return dialog opened — dwelling on period selectors.');
+      await wait(4500);
 
-      for (const labelPattern of [/period/i, /month/i, /year/i, /quarter/i]) {
+      for (const labelPattern of [/period/i, /month/i, /year/i, /quarter/i, /tax.*period/i, /filing.*type|return.*type/i]) {
         const field = page.getByLabel(labelPattern).first();
         if (await field.count() > 0) {
           await field.hover();
-          await wait(900);
+          await wait(1800);
         }
       }
+
+      log('Holding on the populated dialog.');
+      await wait(3500);
 
       log('Closing dialog without creating a return.');
       const cancelBtn = page.getByRole('button', { name: /cancel|close|discard/i }).first();
@@ -53,7 +58,18 @@ export default {
       } else {
         await page.keyboard.press('Escape');
       }
-      await wait(1500);
+      await wait(2000);
+    } else {
+      // Fallback: dwell on the returns list page if no create button surfaces.
+      log('Create return button not found — dwelling on the list view.');
+      await page.evaluate(async () => {
+        const total = document.documentElement.scrollHeight - window.innerHeight;
+        for (let i = 0; i < 10; i++) {
+          window.scrollBy({ top: total / 10, behavior: 'smooth' });
+          await new Promise((r) => setTimeout(r, 320));
+        }
+      });
+      await wait(2500);
     }
 
     log('Recording complete.');


### PR DESCRIPTION
## Summary

Five visual-review corrections from manual spot-check of the previous batch + a recorder-instrumentation change that makes future spot-checks self-service.

### Scenario fixes (visual problems caught by review)

1. **`registration-01`** — was a 404 page (`You've drifted beyond the reef`). Wrong URL: `/Identity/Account/Register` → `/Account/Register`. Also switched to `waitUntil: 'domcontentloaded'` because Turnstile keeps the network indefinitely non-idle.

2. **`exports-01`** — spent ~5s on a sparse `/reports` landing for the firm user before reaching `/reports/cashflow`. Direct-navigates to `/reports/cashflow` now.

3. **`client-management-02`** — ended on the client list because of a closing navigate-back. Removed it — the scenario now ends on the onboarding wizard surface (or the Invite Client dialog if that button matches first).

4. **`share-links-01`** — was on `/reports/cashflow` showing "No cash flow data yet" for etienne. Switched to `/vatreturns` where the real **Manage Shared Links** button lives (`VATReturns.razor:125` → `OpenManageSharedLinksDialog`). The dialog actually opens now.

5. **`transactions-01`** — was looking for an Add Transaction dialog that doesn't exist. `/transactions` toolbar has a `+ Add` **link** (`Href="/vat/entry"`). Pivoted to drive `/vat/entry` directly — the canonical manual-entry form with Quick/Advanced mode toggle and §32 Tax Point Date.

### Recorder infrastructure

- **Final-frame `page.screenshot({ fullPage: true })`** per scenario → `recordings/<id>_final.png`. Visual QA is now trivial: open the PNG, confirm destination rendered. The `OK` exit code only proves no exception was thrown; the screenshot is truth.
- **Default 5s `finalDwellMs` outro** before `context.close` so every recording has breathing room (configurable per scenario).
- `vat-returns-01` + `client-management-01` got bumped dwells to clear the 20s target.

## Durations (ffprobe-verified)

| Scenario              | Duration |
|-----------------------|----------|
| client-management-01  |  26.6s   |
| client-management-02  |  32.6s   |
| compliance-01         |  23.6s   |
| compliance-02         |  23.7s   |
| exports-01            |  28.8s   |
| mobile-01             |  27.5s   |
| performance-01        |  22.6s   |
| registration-01       |  32.5s   |
| share-links-01        |  26.2s   |
| transactions-01       |  30.3s   |
| transactions-03       |  19.8s   |  (within 1% of target) |
| vat-returns-01        |  21.9s   |

## Test plan

- [x] `node run.js --all` against staging — 12/12 OK
- [x] ffmpeg conversion to `dist/videos/*.mp4` — all 12 valid (562KB–1.83MB)
- [x] All 12 `_final.png` screenshots manually inspected — destinations render, no cookie banner, no 404, no login redirect
- [ ] Spot-check the playback (Robbie)