### PR TITLE
docs(attestation): align BICA verification + audit-trail with shipped #3194

### DIFF
--- a/docs/attestation/audit-trail.md
+++ b/docs/attestation/audit-trail.md
@@ -20,7 +20,7 @@ Under [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act,
 
 ## Events Recorded
 
-The attestation audit trail captures events at each stage of the pathway. The current build emits the five lifecycle events listed under **Currently emitted** below; the events under **Planned** are reserved for upcoming features (Handover, Session Affirmation, Carve-Out routing, Digital Filing) — they will start emitting as those features ship. Integrators consuming the audit feed should ignore unknown event types gracefully.
+The attestation audit trail captures events at each stage of the pathway. The current build emits the six lifecycle events listed under **Currently emitted** below; the events under **Planned** are reserved for upcoming features (Handover, Session Affirmation, Carve-Out routing, Digital Filing) — they will start emitting as those features ship. Integrators consuming the audit feed should ignore unknown event types gracefully.
 
 ### Currently emitted
 
@@ -31,13 +31,13 @@ The attestation audit trail captures events at each stage of the pathway. The cu
 | `ATTESTATION_VOIDED_BY_ASSIGNMENT_CHANGE` | The active client assignment was changed, invalidating the prior attestation authority |
 | `ATTESTATION_RE_ATTEST_REQUIRED` | A return change after attestation requires re-attestation before submission |
 | `ATTESTATION_MODAL_CANCELLED` | The filer cancelled the attestation confirmation modal before submitting |
+| `BICA_VERIFICATION_ATTEMPTED` | A BICA licence verification was attempted. Description names the client business and embeds the resolved state (`Verified` / `NotFound` / `Expired` / `Unreachable` / `Stale`). See [BICA Verification](/docs/attestation/bica-verification) for the canonical Description lines. |
 
 ### Planned (not yet emitted)
 
 | Event | Status / target feature |
 |-------|-------------------------|
 | `ATT_SESSION_STARTED` / `ATT_QUALIFIER_COMPLETED` | Planned with [Qualifying Screen](/docs/attestation/qualifying-screen) instrumentation |
-| `ATT_BICA_VERIFIED` / `ATT_BICA_FALLBACK` | Planned with [BICA Verification](/docs/attestation/bica-verification) live registry check |
 | `ATT_SESSION_AFFIRMED` / `ATT_SESSION_AFFIRMATION_FAILED` | Planned with [Session Affirmation](/docs/attestation/session-affirmation) live capture |
 | `ATT_HANDOVER_INITIATED` / `_ACCEPTED` / `_RECALLED` / `_EXPIRED` | Planned with [Handover](/docs/attestation/handover) feature |
 | `ATT_CARVEOUT_APPLIED` | Planned with [Carve-Outs](/docs/attestation/carve-outs) routing instrumentation |

--- a/docs/attestation/bica-verification.md
+++ b/docs/attestation/bica-verification.md
@@ -23,24 +23,30 @@ When an accountant selects the Professional Accountant pathway on the [Qualifyin
 
 ## Verification Outcomes
 
-| Result | Meaning | Next Step |
-|--------|---------|-----------|
-| **Verified — Active** | Membership is current and in good standing | Proceed to the Professional Accountant declaration |
-| **Verified — Renewal Pending** | Membership is within 30 days of renewal; still valid | A warning is shown; you may proceed |
-| **Not Verified — Lapsed** | Membership has expired | Contact BICA to renew before filing |
-| **Not Verified — Suspended** | Membership is currently suspended | You cannot use this variant; use [Authorized Agent Variant](/docs/attestation/variant-agent) or arrange for a colleague to file |
-| **Not Verified — Not Found** | Number not found in registry | Check for typos; contact BICA if the issue persists |
-| **Service Unavailable** | BICA registry is temporarily unreachable | See [Fallback Procedure](#fallback-procedure) below |
+CoralLedger Comply consumes the official **BICA Listing of Licensees** PDF and the **Find-a-Member** web surface, then writes the outcome to the [Attestation Audit Trail](/docs/attestation/audit-trail) as a `BICA_VERIFICATION_ATTEMPTED` event. The outcome resolves to one of four canonical states:
 
-## Renewal Pending Warning
+| State | Description (regulator-visible) | Next Step |
+|---|---|---|
+| **Verified** | BICA licence verified — licence current; expiry date carried from the listing. | Proceed to the Professional Accountant declaration. |
+| **NotFound** | BICA licence checked — no record on the BICA register. | Check for typos; contact BICA if the issue persists. |
+| **Expired** | BICA licence checked — record found, licence expired (date carried from the listing). | Contact BICA to renew before filing. |
+| **Unreachable** | BICA licence check could not be completed — BICA register did not respond. | See [Fallback Procedure](#fallback-procedure) below. |
 
-If your membership is within 30 days of its renewal date, a warning banner is shown before the declaration:
+The four-word state token (`Verified` / `NotFound` / `Expired` / `Unreachable`) is the machine-stable identifier used by audit consumers and regulator inspectors. The prose around each line is editorial and may evolve; the state token is the contract.
 
-:::warning BICA Renewal Due Soon
-Your BICA membership (No: XXXX) is due for renewal on [date]. Your attestation is valid today, but you must renew before that date to continue using the Professional Accountant Variant for future filings.
+:::note Defensive downgrade — `Stale`
+When the listing PDF and Find-a-Member surface disagree (e.g. licence present in one but not the other), or when the cached listing is older than seven days, the result is defensively downgraded to a fifth internal state, `Stale`. From the filer's perspective this surfaces the same warning treatment as `Unreachable` and the filer cannot use the Professional Accountant Variant until the next refresh resolves the disagreement.
 :::
 
-You may proceed with the attestation despite this warning. The renewal reminder is also written to the [Attestation Audit Trail](/docs/attestation/audit-trail) for record-keeping purposes.
+## Verb Choice (Honest Language)
+
+The Description verb in the audit row reflects what actually happened:
+
+- **verified** — used only when verification succeeded (`Verified` state).
+- **checked** — used when the BICA register answered with a definitive negative (`NotFound`, `Expired`).
+- **check could not be completed** — used when no check happened (`Unreachable` — the register did not respond).
+
+This honesty discipline is per the regulatory product owner's sign-off (CLR-2026-04-COMPLY-01).
 
 ## Fallback Procedure
 
@@ -60,17 +66,28 @@ Manual fallback events are flagged in the [Attestation Audit Trail](/docs/attest
 
 ## Verification Record
 
-Every verification attempt — whether successful or not — is recorded in the attestation session data:
+Every verification attempt — whether successful or not — is recorded in the [Attestation Audit Trail](/docs/attestation/audit-trail) as a `BICA_VERIFICATION_ATTEMPTED` event. The event carries both a regulator-visible **Description** line and a structured **metadata** payload:
+
+### Description (regulator-visible)
+
+The Description line names the **business** being attested for (not the practitioner) and embeds the four-word state token. Example for the `Unreachable` state:
+
+> `BICA licence check could not be completed for Atlantis Hotel Group — Unreachable; BICA register did not respond`
+
+### Metadata payload (machine-readable)
 
 | Field | Contents |
 |-------|----------|
-| **Membership Number** | As entered by the accountant |
-| **Verification Method** | Live Registry Lookup or Manual Fallback |
-| **Verification Result** | Verified / Not Verified / Fallback |
-| **Timestamp** | UTC date and time of the check |
-| **Registry Response** | Status code returned by the BICA registry |
+| `LicenceNumber` | Normalised BICA identifier as supplied by the practitioner |
+| `state` | One of `Verified` / `NotFound` / `Expired` / `Stale` / `Unreachable` |
+| `PractitionerName` | Name surfaced from the BICA listing (when present) |
+| `ListingDate` | Licence expiry / activity date from the listing (when present) |
+| `ListingPublishedAt` | UTC timestamp the listing PDF was published |
+| `FromCache` | `true` when the result was served from the 24-hour distributed cache |
+| `FindAMemberAgreement` | Whether the Find-a-Member supplementary surface agreed with the listing |
+| `StaleReason` | Explanation when the state was defensively downgraded to `Stale` |
 
-This record is included in the [Attestation Audit Trail](/docs/attestation/audit-trail) entry for the submission.
+The `state=` syntax appears only in the structured metadata, never in the regulator-visible Description.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Companion to [coralledgercomply#3392](https://github.com/caribdigital/coralledgercomply/pull/3392) (shipped — BICA audit Description uses business name per Cass's CLR-2026-04-COMPLY-01 canonical lines).

The docs were describing a different BICA verification surface than what actually ships:

| Where | Drift |
|---|---|
| `bica-verification.md` "Verification Outcomes" | Named 6 outcomes — including "Verified — Renewal Pending" and "Not Verified — Suspended" that don't exist in the `BicaVerificationStatus` enum. Actual enum: `Verified` / `NotFound` / `Expired` / `Unreachable` (+ defensive `Stale`). |
| `bica-verification.md` "Verification Record" | Listed pre-implementation fields ("Verification Method", "Verification Result") instead of the actually-emitted audit fields (`state`, `ListingDate`, `ListingPublishedAt`, `FromCache`, `FindAMemberAgreement`, `StaleReason`). |
| `audit-trail.md` event tables | `BICA_VERIFICATION_ATTEMPTED` was listed as **Planned** with the wrong event name (`ATT_BICA_VERIFIED` / `ATT_BICA_FALLBACK`). The actual event has been live for some time. |

## Changes

- **`bica-verification.md`**
  - Verification Outcomes table now uses the four canonical states + Description language from Cass's sign-off.
  - New "Verb Choice (Honest Language)" section captures Cass's verb-shift rule: *verified* (only on `Verified`) / *checked* (`NotFound`, `Expired`) / *check could not be completed* (`Unreachable`).
  - "Verification Record" rewritten to show the Description (regulator-visible) + metadata payload (machine-readable) the audit ledger actually emits.

- **`audit-trail.md`**
  - Moves `BICA_VERIFICATION_ATTEMPTED` from "Planned" to "Currently emitted" with a cross-reference to the BICA Verification page.
  - Removes the stale planned-event row.

## Test plan

- [x] `npx docusaurus build` — green
- [x] Cross-reference verified against `BicaVerificationStatus.cs` and `BicaVerificationService.BuildAuditDescription` (canonical reference, per platform-canonical-check rule)