### PR TITLE
docs: split support email — hello@ for general, privacy@ for DSR only (#136)

### DIFF
--- a/docs/billing/licensing.md
+++ b/docs/billing/licensing.md
@@ -61,7 +61,7 @@ If you have a license key:
 You enter a grace period with read-only access. Your data is preserved. Activate a license to restore full access.
 
 ### Can I switch plans?
-Yes. Contact privacy@digitalcarib.com to discuss plan changes.
+Yes. Contact hello@digitalcarib.com to discuss plan changes.
 
 ### What's the cancellation policy?
 You can cancel at any time. Your data is retained for 7 years per [Value Added Tax Act, 2014, s. 50](https://laws.bahamas.gov.bs/).
@@ -73,4 +73,4 @@ Yes. Founding Members pay $99/mo forever, regardless of future price increases.
 
 - [View subscription details](/docs/billing)
 - [Join the Founders Circle](/docs/billing/founders-circle)
-- [Contact support](mailto:privacy@digitalcarib.com)
+- [Contact support](mailto:hello@digitalcarib.com)

--- a/docs/compliance/vat-2025-reforms.md
+++ b/docs/compliance/vat-2025-reforms.md
@@ -161,7 +161,7 @@ CoralLedger Comply includes dedicated dashboards for each 2025 reform:
 ## Need Help?
 
 The 2025 reforms are complex. Contact us for assistance:
-- **Email**: privacy@digitalcarib.com
+- **Email**: hello@digitalcarib.com
 - **Phone**: Schedule a consultation
 
 ## Next Steps

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -49,6 +49,6 @@ CoralLedger Comply is a VAT compliance platform built specifically for businesse
 
 ## Need Help?
 
-- **Email**: privacy@digitalcarib.com
+- **Email**: hello@digitalcarib.com
 - **Documentation**: You're already here!
 - **In-App Help**: Access the Help Center from within CoralLedger Comply

--- a/docs/getting-started/performance.mdx
+++ b/docs/getting-started/performance.mdx
@@ -68,7 +68,7 @@ If you experience slow performance:
 
 1. Clear your browser cache and reload the page
 2. Check your internet connection speed
-3. If the issue persists, contact [privacy@digitalcarib.com](mailto:privacy@digitalcarib.com) with:
+3. If the issue persists, contact [hello@digitalcarib.com](mailto:hello@digitalcarib.com) with:
    - The page URL where slowness occurs
    - The action you were taking when slowness started
    - Your browser + version (and approximate connection speed if known)

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -31,7 +31,7 @@ We're working on direct integrations with:
 - Bank feeds
 
 :::info Request an Integration
-Need a specific integration? Email us at privacy@digitalcarib.com
+Need a specific integration? Email us at hello@digitalcarib.com
 :::
 
 ## API Access

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -77,4 +77,4 @@ Per-section verification of VAT Act amendment chains — sign-off by Julian Roll
 ## Need Help?
 
 Contact CoralLedger Support:
-- **Email**: privacy@digitalcarib.com
+- **Email**: hello@digitalcarib.com

--- a/docs/security/two-factor-auth.md
+++ b/docs/security/two-factor-auth.md
@@ -98,7 +98,7 @@ You can disable 2FA from the same settings panel. Doing so requires re-entering 
 
 If you've lost both your phone and your backup codes:
 
-1. Contact privacy@digitalcarib.com
+1. Contact hello@digitalcarib.com
 2. You'll need to verify your identity through an out-of-band channel
 3. An administrator can reset your 2FA
 

--- a/docs/settings/index.md
+++ b/docs/settings/index.md
@@ -133,7 +133,7 @@ Access at **Settings > Privacy**.
 
 ## Support
 
-- **Email**: privacy@digitalcarib.com
+- **Email**: hello@digitalcarib.com
 - **Documentation**: docs.coralledger.com
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Closes #136. A prior sweep replaced `support@coralledger.com` with `privacy@digitalcarib.com` sitewide, but `privacy@` is the Bahamian Data Protection Act 2003 data-subject-rights contact path — using it for billing questions, 2FA recovery, or general support is semantically wrong and risks blurring DSR bookkeeping.

Founder decision this session: **split**.

| Address | Where |
|---|---|
| `privacy@digitalcarib.com` | DSR / footer only — `docusaurus.config.ts:168` (footer Privacy link) and `docs/settings/account.md:63` (DPA reference) |
| `hello@digitalcarib.com` | Everywhere else (9 sites). Matches the marketing site footer already in use. |

## Changes

9 sites moved from `privacy@` → `hello@`:

- `docs/billing/licensing.md` (plan-change Q&A + "Contact support" link)
- `docs/compliance/vat-2025-reforms.md` ("Need Help")
- `docs/getting-started/index.md` ("Need Help")
- `docs/getting-started/performance.mdx` (perf issue reporting)
- `docs/integrations/index.md` ("Request an Integration")
- `docs/reference/index.md` ("Need Help")
- `docs/security/two-factor-auth.md` (2FA lost-access recovery)
- `docs/settings/index.md` ("Support")

## Test plan

- [x] `npx docusaurus build` — green
- [x] Sitewide grep: `privacy@` remains in 2 DSR-only sites; `hello@` in 9 support sites; `@coralledger.com` 0 hits
- [ ] Founder: confirm `hello@digitalcarib.com` mailbox is real and routes to a person before merge