### PR TITLE
Strip Julian Rolle FCA / JR-007 / JR-008 attribution from public docs

### DIFF
--- a/docs/reference/amendment-chain-verification-memo.md
+++ b/docs/reference/amendment-chain-verification-memo.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 5
-title: JR-008 — Amendment Chain Verification Memo
-description: CCO sign-off memo verifying amendment chains for §26, §41(3), §44, §50, §60, §61 (DDS-005 follow-up)
+title: Amendment Chain Verification Memo
+description: In-house verbatim verification of amendment chains for §26, §41(3), §44, §50, §60, §61 (DDS-005 follow-up). Independent third-party review pending.
 ---
 
-# JR-008 — Amendment Chain Verification Memo (DDS-005 Follow-up)
+# Amendment Chain Verification Memo (DDS-005 Follow-up)
 
 :::warning §50 row SUPERSEDED 2026-05-31
 The `§50 | Retention period (seven years)` row in the scope table below was superseded on 2026-05-31. A source-verification of the Value Added Tax Act, 2014 (consolidated, reprinted 1 July 2024) established that **§50 is "Rules relating to a claim for input tax deduction"** and has no bearing on record retention. The canonical retention authority is **Part X, §§79–80** — §79(2) sets the 5-year statutory minimum that CoralLedger Comply extends to 7 years. Findings 2 and 3 of this memo are accurate **for the other sections covered** (§26, §41(3), §44, §60, §61), pending a separate source re-verification of §26 and §41(3) that has been scheduled. See [`CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md`](https://github.com/caribdigital/coralledgercomply/blob/master/tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md) for the verification bundle.
@@ -88,9 +88,8 @@ The following sections remain cited under the 2021 chain because they were subst
 
 ## Verification
 
-Sign-off confirming the research basis, the findings, and the documentation changes described in this memo:
+This memo documents a verbatim section-by-section comparison of the VAT Act 2014 baseline against the gazetted Amendment Acts (2014–2026). The methodology is **design-against-statute**: each amendment chain entry references the exact section reference (e.g. §6(1)(c), §32(17)) and the enacting instrument, read directly from the gazetted PDFs in the project knowledge base.
 
-- **Julian Rolle** (Chief Compliance Officer) — Section-by-section amendment chain review
-- **Cass** (Documentation Lead) — Documentation update execution
+**Independent third-party review** by a credentialed Bahamian VAT practitioner is being arranged. Until that review completes and the reviewer's sign-off is published here, the position stated in this memo represents an in-house verbatim mapping against the gazetted text — not an independent professional opinion.
 
-**Signed on:** 2026-05-12 (UTC)
+**In-house mapping last updated:** 2026-06-06 (UTC)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -53,8 +53,8 @@ Record-only close-out documenting Cass remediation items already clean on `main`
 
 [View Audit Verification Record (2026-05-30)](/docs/reference/audit-verification-2026-05-30)
 
-### Amendment Chain Verification Memo (JR-008)
-Per-section verification of VAT Act amendment chains — sign-off by Julian Rolle (CCO) and Cass:
+### Amendment Chain Verification Memo
+Per-section verification of VAT Act amendment chains against the gazetted Amendment Acts (2014–2026). In-house verbatim mapping against the gazetted text; independent third-party practitioner review pending.
 
 [View Amendment Chain Verification Memo](/docs/reference/amendment-chain-verification-memo)
 

--- a/docs/reference/statutory-citations.md
+++ b/docs/reference/statutory-citations.md
@@ -44,11 +44,11 @@ When citing a record-keeping or accounts provision (Part X, §§79–80) or any 
 ## Amendment Chain Rules
 
 - Omit the amendment chain when citing a section that has not been amended since the original Act: `[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 26`.
-- Use the **2021 chain** when citing a provision whose substance was changed by the VAT (Amendment) (No. 2) Act, 2021 (e.g., provisions updated as part of the rate reduction to 10% or the redefined international-service definitions). Verified under JR-008.
-- Use the **2025 chain** when citing provisions introduced or updated by the VAT (Amendment) (No. 2) Act, 2025 (for example, the licensed food-store reduced-rate provision under JR-007).
+- Use the **2021 chain** when citing a provision whose substance was changed by the VAT (Amendment) (No. 2) Act, 2021 (e.g., provisions updated as part of the rate reduction to 10% or the redefined international-service definitions).
+- Use the **2025 chain** when citing provisions introduced or updated by the VAT (Amendment) (No. 2) Act, 2025 (for example, the licensed food-store reduced-rate provision).
 - If more than one amending Act is material to the cited provision, list each in chronological order using `and`.
 
-### Sections verified as unamended since 2014 (JR-008)
+### Sections verified as unamended since 2014
 
 The following sections were confirmed as unamended since the original Value Added Tax Act, 2014, and must **not** carry any amendment-chain qualifier:
 
@@ -62,7 +62,7 @@ The following sections were confirmed as unamended since the original Value Adde
 | s. 61 | Penalties |
 
 :::warning Citation re-verification in progress
-The `s. 26` and `s. 41(3)` entries above are carried forward from JR-008 (May 2026) but have **not** been re-verified at source. The `s. 50` citation that appeared in this table was verified at source on 2026-05-31 and found to be incorrect: §50 of the VAT Act 2014 is "Rules relating to a claim for input tax deduction", not the retention period. The canonical retention authority is **Part X, §§79–80** (§79(2) sets the 5-year statutory minimum). A follow-up verification of §26 and §41(3) is scheduled — both may need similar correction.
+The `s. 26` and `s. 41(3)` entries above are carried forward from an earlier in-house verification (May 2026) but have **not** been re-verified at source. The `s. 50` citation that appeared in this table was verified at source on 2026-05-31 and found to be incorrect: §50 of the VAT Act 2014 is "Rules relating to a claim for input tax deduction", not the retention period. The canonical retention authority is **Part X, §§79–80** (§79(2) sets the 5-year statutory minimum). A follow-up verification of §26 and §41(3) is scheduled — both may need similar correction.
 :::
 
 Canonical amendment-chain examples:

--- a/docs/statutes/output-tax-calculation-declaration.md
+++ b/docs/statutes/output-tax-calculation-declaration.md
@@ -17,11 +17,11 @@ The Bahamas VAT system applies four categories:
 - **Standard** (10%) — most goods and services, per s. 10
 - **Reduced** (5%) — hygiene products and medications at licensed food stores, per [VAT (Amendment) Act 2024, s. 12A](https://laws.bahamas.gov.bs/)
 - **Zero-Rated** (0%) — qualifying exports (per s. 22) and specified essentials
-- **Exempt** — services where no VAT is charged and no input tax is recoverable (financial services, residential rent, etc.); also unprepared food at licensed food stores from April 1, 2026 per [VAT (Amendment) (No. 2) Act, 2025](https://laws.bahamas.gov.bs/), s. 2 (JR-007)
+- **Exempt** — services where no VAT is charged and no input tax is recoverable (financial services, residential rent, etc.); also unprepared food at licensed food stores from April 1, 2026 per [VAT (Amendment) (No. 2) Act, 2025](https://laws.bahamas.gov.bs/), s. 2
 
 Output tax is not just a single total. It is a structured declaration that depends on correct categorization, timing, and adjustment handling across all sales-related activity.
 
-### JR-008 — Seller-axis rule for unprepared food
+### Seller-axis rule for unprepared food
 
 The April 2026 food exemption applies on a **seller axis**:
 


### PR DESCRIPTION
## Summary

A previous pass stripped named-reviewer attribution from the marketing /compliance page. This sweep applies the same standard to the docs site, which still carried the attribution in several places.

## Surfaces touched (4 files, +14 / -15 net)

| File | Was | Now |
|---|---|---|
| `docs/reference/amendment-chain-verification-memo.md` | Title + H1 prefixed "JR-008 —", description "CCO sign-off memo", Verification section listed Julian Rolle (CCO) + Cass as signed-off reviewers (2026-05-12) | Title + H1 with no prefix, description "In-house verbatim verification … Independent third-party review pending", Verification section is now a design-against-statute methodology block + explicit "Independent third-party review by a credentialed Bahamian VAT practitioner is being arranged" line |
| `docs/reference/index.md` | Section "Amendment Chain Verification Memo (JR-008) — sign-off by Julian Rolle (CCO) and Cass" | "Amendment Chain Verification Memo … In-house verbatim mapping against the gazetted text; independent third-party practitioner review pending" |
| `docs/reference/statutory-citations.md` | Three inline references: "Verified under JR-008", "(under JR-007)", "(JR-008)" heading qualifier, "carried forward from JR-008" inside the re-verification warning | All four stripped or reframed (statute references intact) |
| `docs/statutes/output-tax-calculation-declaration.md` | "(JR-007)" inline citation qualifier + "JR-008 —" heading prefix | Both stripped |

## Rationale

Per the fabricated-reviewer-attribution standard: naming a credentialed reviewer (FCA, CPA, BICA) on public Bahamian VAT compliance pages is a representation about a real human's professional review. Until a genuine independent third-party practitioner sign-off lands, neither the named form nor the obfuscated form (internal sign-off-memo IDs like "JR-007"/"JR-008" that are traceable to a named human's initials) belongs in public copy. The anonymized variant ("qualified VAT practitioner") would be the same defect with the name filed off.

## Reframe pattern

- Strip the name / initials prefix from titles and headings.
- Strip inline "(JR-XXX)" parentheticals — they were attribution validators, not actual citation references. The statute citation itself stays.
- Replace the Verification section's named-reviewer sign-off with a design-against-statute methodology block + an explicit "Independent third-party review by a credentialed Bahamian VAT practitioner is being arranged" forward-looking line.

## Out of scope

- The Comply codebase has its own internal-only `//` comments documenting citation provenance for developers — those are not user-facing (compiled away) and remain.
- Marketing site has a sibling PR (caribdigital/coralledger-marketing#424) for a single residual on /resources/guides/bahamas-vat-guide.

## Test plan

- [x] Sweep confirms zero remaining "Julian Rolle" / "JR-007" / "JR-008" attribution surfaces in `docs/`
- [ ] CI green
- [ ] Squash-merge