### PR TITLE
fix(vat-rates): repoint April 2026 food→Exempt citation per Cass's PRIMARY (2026-06-06)

### DIFF
--- a/docs/reference/vat-rates.mdx
+++ b/docs/reference/vat-rates.mdx
@@ -116,7 +116,7 @@ Because exempt supplies block input tax credit recovery, a business selling both
 - **Food store qualification rules effective**: April 1, 2025 — [VAT (Amendment) Act, 2025](https://laws.bahamas.gov.bs/)
 - **Multi-rate framework fully effective**: July 1, 2025 — [VAT (Amendment) (No. 2) Act, 2025](https://laws.bahamas.gov.bs/)
 - **Reduced-rate narrowing (hygiene/medical only) effective**: September 1, 2025 — [VAT (Amendment) Act, 2025](https://laws.bahamas.gov.bs/)
-- **April 2026 food exemption**: April 1, 2026 — unprepared food at licensed food stores moves to Exempt per [VAT (Amendment) (No. 2) Act, 2025](https://laws.bahamas.gov.bs/), s. 2
+- **April 2026 food exemption**: April 1, 2026 — unprepared food at licensed food stores moves to Exempt per [VAT (Amendment) Act 2026 (No. 4)](https://laws.bahamas.gov.bs/), s. 3, Second Schedule Part I item (19)
 :::info Transition Dates
 The 2025 reforms did **not** commence on a single date. CoralLedger Comply applies the correct rate based on the transaction date you enter, using the staged April 1, 2025, July 1, 2025, September 1, 2025, and April 1, 2026 commencement points. Transactions near rate transition dates display applicable rate guidance to help you confirm the correct category.
 :::


### PR DESCRIPTION
## Summary

One-line citation correction on `docs/reference/vat-rates.mdx` per Cass Turnquest's 2026-06-06 PRIMARY/QUOTED/INFERRED tier methodology document.

## Why

The April 1 2026 food→Exempt treatment was attributed to **"VAT (Amendment) (No. 2) Act, 2025, s. 2"** — but that 2025 Act was the 5% food-store regime (effective 1 July 2025), **not** the Exempt treatment. The Exempt treatment derives from a different statutory instrument.

## What

Cass verbatim-read 20260004A.pdf and PRIMARY-verified the correct citation:

```
VAT (Amendment) Act 2026 (No. 4), s. 3, Second Schedule Part I item (19)
```

One line changed.

## Caveat (block-wide)

The other lines in the Effective Dates block (12% increase July 2018 / §10; reduction to 10% Jan 2022 / No.2 Act 2021; the two 2025 lines) carry citations that are **not yet verbatim-verified**. They are not corrected in this PR. A subsequent block-wide verbatim pass will promote or correct those anchors. Only the April-2026 line is verified to ship now.

## Test plan

- [x] One-line edit, no logic; docs site renders normally
- [x] Live URL after merge: `https://docs.coralledger.com/reference/vat-rates#effective-dates`

## References

- Cass+Julian 2026-06-06 PRIMARY/QUOTED/INFERRED tier methodology
- Engineering decision package: `tasks/comply/CASS-DECISION-PACKAGE-2026-06-06.md` (Decision 3)
- Engagement: CLR-2026-04-COMPLY-01
