### PR TITLE
docs: sync regulatory canon to current Comply code (June 2026 reads)

### DIFF
--- a/docs/attestation/index.md
+++ b/docs/attestation/index.md
@@ -54,17 +54,17 @@ Each operation writes a corresponding audit event (`ATTESTATION_CREATED`, `ATTES
 
 ### Attestation bodies — Variants A / B / C and their combinations
 
-Within the firm-admin lifecycle, a BICA-licensed practitioner attests under one of seven `AttestationVariant` bodies. These codes are the statutory body identifiers used by the §32 workflow — not informal practice-area labels:
+Within the firm-admin lifecycle, a BICA-licensed practitioner attests under one of seven `AttestationVariant` bodies. Each variant is a **practice-area declaration** — what the practitioner is attesting to for the client — made under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/) and applicable BICA professional standards:
 
-| Code | Statutory scenario covered |
+| Code | Declaration scope |
 |---|---|
-| **Variant A** | [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32(2) — continuous supply |
-| **Variant B** | [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32(3) — advance payment |
-| **Variant C** | [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32 read with s. 52 — retention |
-| **Variant A+B** | Continuous supply + advance payment |
-| **Variant A+C** | Continuous supply + retention |
-| **Variant B+C** | Advance payment + retention |
-| **Variant A+B+C** | Combined body covering all three statutory scenarios |
+| **Variant A** | **General VAT Compliance Attestation** — the business is in compliance with its general VAT obligations |
+| **Variant B** | **VAT Return Preparation Attestation** — the practitioner prepared or reviewed the VAT return(s) for the period(s) stated |
+| **Variant C** | **VAT Advisory Services Attestation** — VAT advisory services were rendered in accordance with BICA professional standards |
+| **Variant A+B** | General compliance + return preparation |
+| **Variant A+C** | General compliance + advisory services |
+| **Variant B+C** | Return preparation + advisory services |
+| **Variant A+B+C** | Full-scope declaration covering all three practice areas |
 
 Variants A, B, C, and A+B+C have ratified declaration bodies; the remaining three combinations (A+B, A+C, B+C) carry placeholder body text and require the practitioner to select one of the four ratified variants until ratification of the combinations is complete.
 

--- a/docs/attestation/variant-agent.md
+++ b/docs/attestation/variant-agent.md
@@ -32,7 +32,7 @@ If the agent has not been formally added to the business, they cannot select thi
 
 When this variant is active, the following declaration is presented:
 
-> *I declare that I am an authorized agent of the registered person named in this return, that I have been duly authorized to prepare and file this VAT return on their behalf, and that the information provided is, to the best of my knowledge and belief, true, correct, and complete. I understand that as agent I share responsibility for the accuracy of this return and that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/). I further acknowledge that, for **[Client Name]**, [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61 exposes this return to penalties of up to 200% of any understated or over-claimed VAT if the return is materially incorrect.*
+> *I declare that I am an authorized agent of the registered person named in this return, that I have been duly authorized to prepare and file this VAT return on their behalf, and that the information provided is, to the best of my knowledge and belief, true, correct, and complete. I understand that as agent I share responsibility for the accuracy of this return and that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/).*
 
 The agent must confirm this declaration by:
 

--- a/docs/attestation/variant-professional.md
+++ b/docs/attestation/variant-professional.md
@@ -8,7 +8,7 @@ description: Section 32 attestation for BICA-registered accountants preparing VA
 
 The Professional Accountant Variant applies when a **BICA-registered accountant** prepares and files a VAT return on behalf of a client. This variant corresponds to the `SignatoryCapacity.BicaLicensedPractitioner` enum value in the platform, and includes an additional verification step — [BICA Verification](/docs/attestation/bica-verification) — to confirm that the accountant's professional registration is current at the time of filing.
 
-Within this signatory capacity, the practitioner additionally selects one of seven **`AttestationVariant`** bodies that identify the statutory §32 scenario being attested. See [Statutory Attestation Body Selection](#statutory-attestation-body-selection) below.
+Within this signatory capacity, the practitioner additionally selects one of seven **`AttestationVariant`** bodies that identify the practice-area scope being attested. See [Attestation Body Selection](#attestation-body-selection) below.
 
 ## Who Uses This Variant
 
@@ -16,21 +16,21 @@ This variant is presented when the [Qualifying Screen](/docs/attestation/qualify
 
 BICA stands for the **Bahamas Institute of Chartered Accountants**. Members are bound by BICA's Code of Professional Conduct, which includes obligations around accuracy, integrity, and due diligence in tax return preparation.
 
-## Statutory Attestation Body Selection
+## Attestation Body Selection {#attestation-body-selection}
 
-A BICA practitioner attests under one of seven attestation bodies (`AttestationVariant` in the platform). These codes are statutory body identifiers — not practice-area labels:
+A BICA practitioner attests under one of seven attestation bodies (`AttestationVariant` in the platform). Each body is a **practice-area declaration** of what the practitioner is attesting to, made under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/) and applicable BICA professional standards:
 
-| Code | Statutory scenario covered |
+| Code | Declaration scope |
 |---|---|
-| **Variant A** | [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32(2) — continuous supply |
-| **Variant B** | [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32(3) — advance payment |
-| **Variant C** | [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32 read with s. 52 — retention |
-| **Variant A+B** | Continuous supply + advance payment |
-| **Variant A+C** | Continuous supply + retention |
-| **Variant B+C** | Advance payment + retention |
-| **Variant A+B+C** | Combined body covering all three statutory scenarios |
+| **Variant A** | **General VAT Compliance Attestation** — the business is in compliance with its general VAT obligations |
+| **Variant B** | **VAT Return Preparation Attestation** — the practitioner prepared or reviewed the VAT return(s) for the period(s) stated |
+| **Variant C** | **VAT Advisory Services Attestation** — VAT advisory services were rendered in accordance with BICA professional standards |
+| **Variant A+B** | General compliance + return preparation |
+| **Variant A+C** | General compliance + advisory services |
+| **Variant B+C** | Return preparation + advisory services |
+| **Variant A+B+C** | Full-scope declaration covering all three practice areas |
 
-The practitioner selects the variant whose statutory scenario accurately reflects the client's filing facts. The declaration text shown at submission time is determined by the selected variant body. Variants A, B, C, and A+B+C have ratified declaration bodies; the remaining combinations (A+B, A+C, B+C) carry placeholder body text and require selection of one of the four ratified variants until ratification is complete.
+The practitioner selects the variant whose scope accurately reflects the services rendered for the client. The declaration text shown at submission time is determined by the selected variant body. Variants A, B, C, and A+B+C have ratified declaration bodies; the remaining combinations (A+B, A+C, B+C) carry placeholder body text and require selection of one of the four ratified variants until ratification is complete.
 
 ## BICA Verification Requirement
 
@@ -46,9 +46,9 @@ See [BICA Verification](/docs/attestation/bica-verification) for full details on
 
 Once BICA Verification passes, the following declaration is presented:
 
-> *I declare that I am a member in good standing of the Bahamas Institute of Chartered Accountants (BICA Membership No: [XXXX]), that I have prepared this VAT return in my professional capacity on behalf of the registered person named herein, and that the information provided is, to the best of my professional knowledge and belief, true, correct, and complete. I acknowledge my professional obligations under BICA's Code of Professional Conduct and understand that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/). I further acknowledge that, for **[Client Name]**, [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61 exposes this return to penalties of up to 200% of any understated or over-claimed VAT if the return is materially incorrect.*
+> *I declare that I am a member in good standing of the Bahamas Institute of Chartered Accountants (BICA Membership No: [XXXX]), that I have prepared this VAT return in my professional capacity on behalf of the registered person named herein, and that the information provided is, to the best of my professional knowledge and belief, true, correct, and complete. I acknowledge my professional obligations under BICA's Code of Professional Conduct and understand that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/).*
 
-The exact declaration body presented depends on the selected `AttestationVariant` (A, B, C, A+B+C, etc.). See [Statutory Attestation Body Selection](#statutory-attestation-body-selection) above.
+The exact declaration body presented depends on the selected `AttestationVariant` (A, B, C, A+B+C, etc.). See [Attestation Body Selection](#attestation-body-selection) above.
 
 The accountant must confirm this declaration by:
 
@@ -86,7 +86,7 @@ The Professional Accountant Variant carries an explicit professional liability a
 - They have reviewed the underlying transactions and supporting records
 - They are not aware of any material misstatement or omission
 
-This does not transfer legal liability from the registrant to the accountant — under [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32, the registrant remains ultimately responsible, while [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61 continues to govern penalty exposure on an incorrect return — but it does establish the accountant's professional accountability under BICA standards.
+This does not transfer legal liability from the registrant to the accountant — the registrant remains ultimately responsible for the accuracy of the return and for any resulting penalties, interest, and assessment exposure under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/) — but it does establish the accountant's professional accountability under BICA standards.
 
 ## Next Steps
 

--- a/docs/attestation/variant-standard.md
+++ b/docs/attestation/variant-standard.md
@@ -19,7 +19,7 @@ This variant is presented when the [Qualifying Screen](/docs/attestation/qualify
 
 When this variant is active, the following declaration is presented before final submission:
 
-> *I, the undersigned, being the registered person or an officer of the registered person named in this return, hereby declare that the information provided in this VAT return and all accompanying schedules is, to the best of my knowledge and belief, true, correct, and complete. I understand that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/) and may result in penalties, interest, and prosecution. I further acknowledge that, for **[Client Name]**, [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61 exposes this return to penalties of up to 200% of any understated or over-claimed VAT if the return is materially incorrect.*
+> *I, the undersigned, being the registered person or an officer of the registered person named in this return, hereby declare that the information provided in this VAT return and all accompanying schedules is, to the best of my knowledge and belief, true, correct, and complete. I understand that submitting a false or misleading return is an offence under the [Value Added Tax Act, 2014 (as amended)](https://laws.bahamas.gov.bs/) and may result in penalties, interest, and prosecution.*
 
 The filer must confirm this declaration by:
 

--- a/docs/compliance/bad-debt-relief.md
+++ b/docs/compliance/bad-debt-relief.md
@@ -1,58 +1,60 @@
 ---
 sidebar_position: 5
 title: Bad Debt Relief
-description: Claim VAT relief on invoices that remain unpaid for 12 months or more
+description: Claim VAT relief on supplies you have written off as bad debts
 ---
 
 # Bad Debt Relief
 
-Bad Debt Relief allows VAT-registered businesses to reclaim VAT already paid to the government on invoices that remain unpaid for **12 months or more**. CoralLedger Comply tracks eligible debts based on invoice age and guides you through the claim process.
+Bad Debt Relief allows VAT-registered businesses to reclaim VAT already paid to the government on supplies that have been **written off as bad debts**. CoralLedger Comply surfaces long-outstanding debts for your review and guides you through writing them off and claiming the relief.
 
 :::info Legal Basis
-Bad Debt Relief is governed by [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 20, which sets the four-criteria test and permits a registered person to make a deduction in a subsequent VAT return once a debt meets the statutory criteria.
+Bad Debt Relief is governed by [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 53 (post-supply adjustment due to bad debt). Under **s. 53(3)** the relief arises on the **date the bad debt is written off in the registrant's accounts** — there is **no 12-month threshold** in s. 53. The 12-month age that Comply uses to *surface* candidate debts is a convenience prompt, not the statutory trigger.
 :::
 
 ## What Qualifies as a "Bad Debt"
 
-A debt qualifies for relief when **all** of the following conditions are met:
+Relief becomes available when a debt is **written off in your accounts** (s. 53(3)), provided:
 
 | Condition | Detail |
 |-----------|--------|
-| **Age** | The debt is at least 12 months overdue from the original invoice due date |
+| **Written off** | The debt has been formally written off in your accounting records — this is the event that makes relief available under s. 53(3) |
 | **VAT already remitted** | Output VAT on the original supply was declared and paid to the Comptroller |
 | **Collection efforts** | Reasonable steps were taken to recover the debt (documented attempts required) |
-| **Written off** | The debt has been formally written off in your accounting records |
 | **No consideration received** | No full or partial payment has been received against the invoice |
+
+:::note The 12-month age is a prompt, not the trigger
+Comply surfaces debts that are more than 12 months outstanding as **candidates** to consider writing off, shown as a **"Review From"** date. Reaching 12 months does not by itself make a debt eligible — relief becomes available when you write the debt off in your accounts.
+:::
 
 :::warning Partial Payments
 If a partial payment has been received, only the VAT attributable to the **unpaid portion** is eligible for relief.
 :::
 
-## 12-Month Tracking Workflow
+## Bad Debt Tracking Workflow
 
 CoralLedger Comply monitors outstanding invoices and advances them through the following stages:
 
-### Stage 1: Overdue Monitoring (0–11 months)
+### Stage 1: Overdue Monitoring
 - Unpaid invoices appear in the **Accounts Receivable** ageing report
 - The system records the original invoice date, due date, and VAT amount
 - No action is required at this stage
 
-### Stage 2: Approaching Eligibility (Month 10–11)
-- CoralLedger flags invoices that will reach the 12-month threshold within 60 days
+### Stage 2: Surfaced for Review ("Review From")
+- CoralLedger surfaces invoices that have been outstanding for more than 12 months as **candidates** to consider writing off, shown with a **"Review From"** date
 - An **alert** appears on the Compliance dashboard recommending you review and document collection efforts
-- Ensure collection attempts are recorded before the debt becomes eligible
+- This is a prompt to review — it does **not** by itself make the debt eligible for relief
 
-### Stage 3: Eligible for Relief (Month 12+)
+### Stage 3: Review and Write Off
 1. Navigate to **Compliance > Bad Debt**
-2. The dashboard lists all debts that have met the 12-month threshold
-3. Each entry shows:
+2. The dashboard lists surfaced candidate debts. Each entry shows:
    - Original invoice number and date
    - Customer/debtor name
    - Invoice value (gross and net)
    - Original VAT amount
-   - Relief amount available
-4. Review and confirm each eligible debt
-5. Click **Mark as Written Off** to formally write off the debt in CoralLedger
+   - Relief amount available on write-off
+3. Confirm collection efforts are documented for each debt
+4. Click **Mark as Written Off** to formally write off the debt in CoralLedger — this is the event that makes the relief available under s. 53(3)
 
 ### Stage 4: Include in VAT Return
 Once debts are written off, the relief amount is queued for inclusion in your next VAT return. See [VAT Return Impact](#vat-return-impact) below.
@@ -99,10 +101,10 @@ Navigate to **Compliance > Bad Debt > Reports** to access:
 
 | Report | Contents |
 |--------|----------|
-| **Eligible Debts Summary** | All debts meeting the 12-month threshold, grouped by period |
+| **Candidate Debts Summary** | All surfaced candidate debts (more than 12 months outstanding), grouped by period |
 | **Written-Off Debts** | Confirmed write-offs with relief amounts claimed |
 | **Claim History** | Period-by-period history of all relief amounts included in returns |
-| **Outstanding Monitoring** | Debts currently being tracked (0–11 months) |
+| **Outstanding Monitoring** | Debts currently being tracked |
 
 ### What Is Recorded per Claim
 
@@ -127,10 +129,10 @@ CoralLedger links the original transaction and return period to each claim, maki
 ## Step-by-Step Claim Guide
 
 1. Go to **Compliance > Bad Debt**
-2. Review the **Eligible Debts** tab — only debts ≥ 12 months overdue appear here
+2. Review the **Candidate Debts** tab — debts surfaced for review (more than 12 months outstanding) appear here
 3. For each debt, confirm:
    - Collection efforts are documented
-   - The debt has been written off in your books
+   - The debt is being written off in your books
 4. Select the debt(s) to claim and click **Write Off & Claim Relief**
 5. The system calculates the relief amount and schedules it for your next return
 6. When you generate your next VAT return, the relief amount is placed into **Line 16**
@@ -142,8 +144,8 @@ CoralLedger links the original transaction and return period to each claim, maki
 **Can I claim Bad Debt Relief on a debt that was later paid?**
 No. If a debtor subsequently pays after you have claimed relief, you must repay the VAT to the Comptroller by including the amount as output VAT in the return for the period in which payment was received. CoralLedger alerts you if a written-off debt receives a payment.
 
-**What if the debt is partially paid before 12 months?**
-You cannot claim relief until the full 12-month period has elapsed from the original due date. However, when the 12-month threshold is reached, you may claim relief on the outstanding balance only.
+**What if the debt is partially paid?**
+Relief is available only on the **unpaid portion**. Write off the outstanding balance in your accounts and the relief is calculated on the VAT attributable to that unpaid amount.
 
 **Is there a time limit for making a claim?**
 Claims should be made as soon as the debt qualifies. There is no indefinite carry-forward — consult your tax advisor for the applicable limitation period under Bahamas VAT law.

--- a/docs/compliance/compliance-score.mdx
+++ b/docs/compliance/compliance-score.mdx
@@ -8,6 +8,10 @@ description: Understanding your CoralLedger Comply compliance score
 
 Your compliance score helps you understand your VAT compliance health at a glance.
 
+:::note A factual health indicator — not an attestation
+The compliance score is a **factual status indicator** of how your data and filing history look against the platform's checks. It is **not** an attestation that your returns are correct, and it is not a guarantee against assessment or penalty. Treat it as a prompt to review, not a sign-off.
+:::
+
 ## Score Grades
 
 | Grade | Score Range | Status |
@@ -42,6 +46,14 @@ Your score is calculated from four weighted components:
 - Complete transaction records
 - Supporting documentation attached
 - Audit trail maintained
+
+## When the score is capped
+
+If you have **overdue, unfiled returns**, your overall score is **capped** by filing timeliness regardless of how strong the other factors are — an outstanding statutory obligation is the dominant risk. The dashboard always shows a strip explaining the cap, including the earliest overdue period, so the cap is never silent.
+
+## Transactions pending review
+
+Transactions still awaiting review are **excluded** from the score until they are promoted (VAT-category confirmed and audit-gated). Rather than silently ignoring them, the dashboard surfaces the **pending-review count** with a link to the review queue, so an empty or provisional period is never presented as "all clear".
 
 ## Improving Your Score
 

--- a/docs/compliance/index.md
+++ b/docs/compliance/index.md
@@ -10,9 +10,10 @@ CoralLedger Comply helps you maintain VAT compliance with real-time monitoring, 
 
 ## Why Compliance Matters
 
-Non-compliance with Bahamas VAT regulations can result in:
-- **Penalties** - Up to 200% of unpaid VAT ([Value Added Tax Act, 2014, s. 61](https://laws.bahamas.gov.bs/))
-- **Interest** - 5% monthly on late payments
+Non-compliance with Bahamian VAT regulations can result in:
+- **Late-filing fine** - The greater of $100 or 2% of the tax payable ([Value Added Tax Act, 2014, s. 47A(3)(a)](https://laws.bahamas.gov.bs/))
+- **Late-payment fine** - 10% of the tax owed ([s. 47A(3)(b)](https://laws.bahamas.gov.bs/))
+- **Interest** - On outstanding tax at the Central Bank of The Bahamas prime lending rate plus 1% ([s. 47A(4)](https://laws.bahamas.gov.bs/))
 - **Audits** - Increased scrutiny from DIR
 - **License Issues** - Business license complications
 
@@ -45,7 +46,7 @@ Our system flags potential issues:
 Dedicated dashboards for new regulations:
 - **Construction VAT** - $1M threshold tracking
 - **Refund Eligibility** - 50% zero-rated rule monitoring
-- **Bad Debt Relief** - 12-month debt tracking
+- **Bad Debt Relief** - write-off relief tracking (VAT Act s. 53(3))
 - **Tax Savings** - Recovery opportunity detection
 
 ### Alerts

--- a/docs/compliance/intelligence-dashboard.md
+++ b/docs/compliance/intelligence-dashboard.md
@@ -45,14 +45,22 @@ Your overall compliance health displayed as a letter grade (A+ to F):
 
 ### Penalty Risk Assessment
 
-Calculates your exposure under [Value Added Tax Act, 2014, s. 61](https://laws.bahamas.gov.bs/):
+Calculates your exposure to the late-filing and late-payment fines set out in [Value Added Tax Act, 2014, s. 47A](https://laws.bahamas.gov.bs/):
 - Current penalty exposure amount
 - Risk factors contributing to exposure
 - Recommended actions to reduce risk
 
 :::warning Penalty Rates
-The [Value Added Tax Act, 2014, s. 61](https://laws.bahamas.gov.bs/) allows penalties up to 200% of unpaid VAT, plus 5% monthly interest.
+Late filing is fined at the **greater of $100 or 2% of the tax payable**, and late payment at **10% of the tax owed**, with **interest on outstanding tax at the Central Bank of The Bahamas prime lending rate plus 1%** ([Value Added Tax Act, 2014, s. 47A](https://laws.bahamas.gov.bs/)). Section 61 of the Act is an evidentiary provision (*"Assessment as evidence in proceedings"*), **not** a penalty section — there is no "200% of unpaid VAT" multiplier.
 :::
+
+### Risk Indicators
+
+Each risk indicator is shown as a **level and a direction** — a current value against a threshold, with a status of **Normal**, **Warning**, or **Critical**. Indicators describe where a metric stands and which way it is trending; they are not a prediction that a figure will reach zero.
+
+### Provisional figures and pending review
+
+Money figures are presented **neutrally** — Net VAT can be a payable or a refund, and is never coloured as "good" or "bad". When a period still has transactions awaiting review, the dashboard marks the Net VAT figure as **provisional** ("Provisional — N pending review; promote before filing") and shows how the figure would change once those items are promoted. Promote pending items before relying on the number for filing.
 
 ### Data Quality Score
 

--- a/docs/compliance/vat-2025-reforms.md
+++ b/docs/compliance/vat-2025-reforms.md
@@ -27,16 +27,15 @@ From April 1, 2026, unprepared food at licensed food stores moved to **Exempt** 
 
 ### Construction VAT Restrictions
 
-New rules for construction projects exceeding $1 million:
+[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 50 restricts input-VAT recovery on major construction projects.
 
-**What Changed:**
-- Input VAT on construction materials may be restricted
-- Developer exemptions have specific qualification criteria
-- Project value tracking is now required
+**What the rule does:**
+- Under **s. 50(1A)**, input VAT on a major construction project is **prohibited** from being claimed where the project meets a qualifying limb — the principal limb being a project cost **strictly greater than $1,000,000**. Other qualifying limbs include substantial renovation and waterfront works (docks, marinas, and similar).
+- Under **s. 50(1B)**, an **ordinary-course-supplier carve-out** applies, and the Comptroller may prescribe further exceptions.
 
 **How Comply Helps:**
-- Track project values against the $1M threshold
-- Monitor input VAT restrictions with period-based tracking
+- Track project values against the $1M threshold (strictly greater than $1,000,000)
+- Apply the s. 50(1A) restriction and the s. 50(1B) carve-out from a single source of truth
 - Generate compliance reports for construction projects
 
 Access the Construction VAT dashboard at **Compliance > Construction VAT**.
@@ -108,15 +107,17 @@ Because no input tax credit is available on exempt supplies, food stores that no
 - Apportionment ratio calculation and monitoring
 - Alerts when exempt supply proportion increases your non-recoverable input VAT exposure
 
-### Bad Debt Relief (12-Month Rule)
+### Bad Debt Relief
 
-Claim relief on bad debts after 12 months. See the [Bad Debt Relief](/docs/compliance/bad-debt-relief) page for the full workflow.
+Claim relief on bad debts you have written off in your accounts (VAT Act s. 53(3)). See the [Bad Debt Relief](/docs/compliance/bad-debt-relief) page for the full workflow.
 
 **Eligibility:**
-- Debt must be at least 12 months overdue
-- VAT was originally paid to the government
+- The debt is **written off** in your books — the event that makes relief available under s. 53(3)
+- VAT was originally paid to the government on the supply
 - Reasonable collection efforts were made
-- Debt is written off in your books
+- No payment has been received against the unpaid amount
+
+Comply surfaces debts more than 12 months outstanding as candidates to review — a prompt, not the statutory trigger.
 
 **How to Claim:**
 1. Go to **Compliance > Bad Debt**
@@ -137,7 +138,7 @@ CoralLedger Comply includes dedicated dashboards for each 2025 reform:
 |-----------|----------|---------|
 | Construction VAT | Compliance > Construction VAT | $1M threshold tracking |
 | Refund Eligibility | Compliance > Refund Eligibility | 50% rule monitoring |
-| Bad Debt Relief | Compliance > Bad Debt | 12-month tracking |
+| Bad Debt Relief | Compliance > Bad Debt | Write-off relief tracking |
 | Tax Savings | Compliance > Tax Savings | Recovery opportunities |
 | Apportionment | Compliance > Apportionment | Exempt vs taxable supply ratio and input VAT recovery |
 

--- a/docs/reference/amendment-chain-verification-memo.md
+++ b/docs/reference/amendment-chain-verification-memo.md
@@ -10,6 +10,15 @@ description: In-house verbatim verification of amendment chains for §26, §41(3
 The `§50 | Retention period (seven years)` row in the scope table below was superseded on 2026-05-31. A source-verification of the Value Added Tax Act, 2014 (consolidated, reprinted 1 July 2024) established that **§50 is "Rules relating to a claim for input tax deduction"** and has no bearing on record retention. The canonical retention authority is **Part X, §§79–80** — §79(2) sets the 5-year statutory minimum that CoralLedger Comply extends to 7 years. Findings 2 and 3 of this memo are accurate **for the other sections covered** (§26, §41(3), §44, §60, §61), pending a separate source re-verification of §26 and §41(3) that has been scheduled. See [`CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md`](https://github.com/caribdigital/coralledgercomply/blob/master/tasks/comply/CASS-VAT-ACT-RETENTION-VERIFICATION-2026-05-31.md) for the verification bundle.
 :::
 
+:::warning §61 and §20 entries SUPERSEDED (June 2026 Cass + Julian canon)
+Two further entries in this memo have been superseded by the Cass + Julian verbatim reads of June 2026, which are now the source-of-truth in the Comply codebase:
+
+- **§61 is NOT a penalty section.** It is *"Assessment as evidence in proceedings"*. The "Penalties (up to 200% of unpaid VAT)" description in the scope table below is wrong and has been stripped from the documentation. The late-filing/late-payment fines and interest are set out in **§47A** — late filing: greater of $100 or 2% of tax payable; late payment: 10% of tax owed; interest: prime + 1%.
+- **Bad-debt relief is §53, not §20.** §20 is *Voluntary Registration*. Relief arises on the write-off date under **§53(3)**; there is no 12-month statutory trigger. Finding 1 below (which concluded §20 was correct) is superseded.
+
+These corrections post-date the in-house mapping recorded below.
+:::
+
 ## Scope
 
 This memo records the validation of per-section amendment chains for the Bahamas Value Added Tax Act citations used throughout CoralLedger Comply documentation, as required by issue DDS-005 (PR #104 follow-up).
@@ -24,7 +33,7 @@ The following sections were reviewed:
 | §44 | Partial exemption and input-tax apportionment | vat-returns/input-tax-apportionment.md, statutes/partial-exemption-apportionment.md |
 | ~~§50~~ → Part X, §§79–80 | Record-keeping and accounts (5-year statutory minimum in §79(2); 7-year CoralLedger Comply policy). Corrected 2026-05-31 — original `§50` citation in this memo was wrong; §50 is input-tax-deduction allowability. | audit/index.md, billing/index.md, billing/licensing.md, ops-portal/data-ops.md, settings/account.md, transactions/archived-records.md, statutory-citations.md, security/index.mdx, attestation/audit-trail.md |
 | §60 | Late-payment interest rate | statutes/assessments-interest-penalties.md |
-| §61 | Penalties (up to 200% of unpaid VAT) | compliance/intelligence-dashboard.md, security/index.mdx, statutory-citations.md, statutes/assessments-interest-penalties.md |
+| §61 → ~~Penalties (up to 200%)~~ | **Assessment as evidence in proceedings** (NOT a penalty section). Corrected June 2026 — fines/interest for late filing/payment are §47A; the "up to 200%" figure was a fabrication and has been stripped. | compliance/intelligence-dashboard.md, security/index.mdx, statutory-citations.md, statutes/assessments-interest-penalties.md |
 
 ## Research Basis
 
@@ -47,6 +56,8 @@ Neither the 2021 nor the 2025 amendment Acts amended sections 26, 41(3), 44, 50,
 ## Findings
 
 ### Finding 1: §29 is not the bad-debt-relief section
+
+> **Superseded (June 2026):** this finding concluded that §20 was the correct bad-debt-relief section. That is wrong. Bad-debt relief is **§53** (post-supply adjustment due to bad debt); relief arises on the write-off date under **§53(3)**. §20 is *Voluntary Registration*. The documentation now cites §53(3) throughout. The original finding text is retained below for history.
 
 The issue tracking table referenced "§29" as cited in `compliance/bad-debt-relief.md`. On review, that file correctly cites **§20** (the four-criteria bad-debt-relief test), not §29. No citation of §29 was found in any file at the time of this review. §20 is the correct section for bad debt relief and retains the 2021 amendment chain pending separate validation of whether the 2021 Act changed §20.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -22,7 +22,7 @@ The displayed label for the `AwaitingDirConfirmation` state — the return's art
 ## B
 
 ### Bad Debt Relief
-A provision allowing businesses to claim back VAT on invoices that remain unpaid for 12 months or more. CoralLedger Comply tracks eligible debts by invoice age.
+A provision (VAT Act s. 53(3)) allowing businesses to claim back VAT on supplies they have written off as bad debts in their accounts. CoralLedger Comply surfaces long-outstanding debts (more than 12 months) as candidates to review and write off.
 
 ### Breadbasket Items
 Essential food items eligible for the reduced 5% VAT rate when sold by licensed food stores.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -76,7 +76,7 @@ Per-section verification of VAT Act amendment chains against the gazetted Amendm
 
 - [Department of Inland Revenue](https://inlandrevenue.finance.gov.bs/)
 - [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/)
-- Commonly cited sections in this documentation: s. 26, Part X §§79–80, s. 61
+- Commonly cited sections in this documentation: s. 32 (time of supply), s. 47A (late-filing/payment fines and interest), s. 53 (bad-debt relief), Part X §§79–80 (record retention)
 - [2025 VAT Reforms](https://inlandrevenue.finance.gov.bs/)
 
 ## Need Help?

--- a/docs/reference/statutory-citations.md
+++ b/docs/reference/statutory-citations.md
@@ -25,11 +25,11 @@ Example (s. 32 was substantively changed by the 2021 Act and is a canonical exam
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 26
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 44
 - [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), Part X, §§79–80
-- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61
+- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 47A(3)(a)
 - [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 47(1)(a)
-- [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32(2)
-- [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 32(3)
-- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61(c)
+- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32(8)
+- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 32(11)
+- [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 53(3)
 
 ### Part-and-section citation format
 
@@ -39,7 +39,7 @@ When citing a record-keeping or accounts provision (Part X, §§79–80) or any 
 
 - Keep the same `s.` prefix, then append subsection/paragraph markers immediately after the section number: `s. 47(1)(a)`.
 - Do not add spaces inside subsection markers (`s. 32 (2)` is incorrect).
-- Use the exact nested level required by the source text (for example `s. 32(2)` vs `s. 32(3)`).
+- Use the exact nested level required by the source text (for example `s. 47A(3)(a)` vs `s. 47A(4)`).
 
 ## Amendment Chain Rules
 
@@ -58,8 +58,7 @@ The following sections were confirmed as unamended since the original Value Adde
 | s. 41(3) | Record-keeping requirements and good-faith reliance (citation pending re-verification) |
 | s. 44 | Partial exemption and input-tax apportionment |
 | Part X, §§79–80 | Record-keeping and accounts (5-year statutory retention floor in §79(2); record-types enumeration in §80) |
-| s. 60 | Late-payment interest rate |
-| s. 61 | Penalties |
+| s. 61 | Assessment as evidence in proceedings (**not** a penalty section — no "% of unpaid VAT" multiplier) |
 
 :::warning Citation re-verification in progress
 The `s. 26` and `s. 41(3)` entries above are carried forward from an earlier in-house verification (May 2026) but have **not** been re-verified at source. The `s. 50` citation that appeared in this table was verified at source on 2026-05-31 and found to be incorrect: §50 of the VAT Act 2014 is "Rules relating to a claim for input tax deduction", not the retention period. The canonical retention authority is **Part X, §§79–80** (§79(2) sets the 5-year statutory minimum). A follow-up verification of §26 and §41(3) is scheduled — both may need similar correction.

--- a/docs/statutes/assessments-interest-penalties.md
+++ b/docs/statutes/assessments-interest-penalties.md
@@ -6,13 +6,21 @@ description: Exposure from inaccurate or late VAT compliance and control expecta
 
 # Assessments, Interest, and Penalties
 
-Statutory Basis: [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 60 and s. 61
+Statutory Basis: [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 47A
 
 ## What statute says
 
-[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 60 sets the **late-payment interest rate** (Central Bank of The Bahamas prime lending rate **plus 1%** on the unpaid balance, applied monthly), and [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61 sets **penalties** (up to 200% of unpaid VAT).
+[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 47A sets the **fines for late filing and late payment of a VAT return**:
 
-Where VAT is under-declared, over-claimed, or filed late, the authority may assess additional tax and apply both interest and penalties according to these provisions. Repeated non-compliance typically increases regulatory risk and can lead to deeper scrutiny.
+- **Late filing** — a fine of the **greater of $100 or 2% of the tax payable** (s. 47A(3)(a)). This is a single fine — it is not charged per day, and there is no separate cap.
+- **Late payment** — a fine of **10% of the tax owed** (s. 47A(3)(b)).
+- **Interest** — interest on outstanding tax at the Central Bank of The Bahamas prime lending rate **plus 1%** (s. 47A(4)).
+
+Where VAT is under-declared, over-claimed, or filed late, the Comptroller may raise an assessment for additional tax and apply the fines and interest above. Repeated non-compliance typically increases regulatory risk and can lead to deeper scrutiny.
+
+:::note
+There is no general "percentage of unpaid VAT" penalty multiplier in the VAT Act for ordinary under-declaration. Section 61 of the Act is **"Assessment as evidence in proceedings"** — an evidentiary provision, not a penalty section.
+:::
 
 The legal expectation is proactive accuracy and timeliness. Penalty exposure is often reduced when errors are identified early and corrected promptly.
 

--- a/docs/statutes/bad-debt-relief.md
+++ b/docs/statutes/bad-debt-relief.md
@@ -6,18 +6,23 @@ description: Relief for VAT previously remitted on qualifying unpaid debts
 
 # Bad Debt Relief
 
-Statutory Basis: [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 20
+Statutory Basis: [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 53 (post-supply adjustment due to bad debt)
 
 ## What statute says
 
-[Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 20 sets out the four-criteria test for bad debt relief. A registered person can recover VAT already remitted on supplies that remain unpaid after the statutory conditions are met:
+[Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 53 provides for a post-supply adjustment where a registered person has accounted for output VAT on a supply that is subsequently not paid. Under **s. 53(3)**, the relief arises on the **date the bad debt is written off in the accounts of the registrant** — not after a fixed elapsed-time wait. There is **no 12-month threshold** in s. 53.
 
-1. The debt is **at least 12 months old** from the invoice date
-2. The debt has been **written off** in the registrant's books
-3. The registrant has taken **reasonable steps** to recover the debt
-4. The original supply was a **taxable supply** on which output VAT was accounted for
+To claim relief, the registrant must have:
 
-The legal policy is corrective: if output VAT was paid on a supply that is not ultimately collected, the law may permit relief to avoid permanent overpayment.
+1. Accounted for output VAT on the original **taxable supply**
+2. **Written off** the debt in its accounts — this is the event that makes relief available under s. 53(3)
+3. Retained evidence of the debt and of reasonable steps taken to recover it
+
+If a debt on which relief was claimed is later paid, the relief must be reversed in a subsequent return.
+
+:::note The 12-month age is a prompt, not the trigger
+CoralLedger Comply surfaces debts that are more than 12 months outstanding as **candidates** to consider writing off — a convenience heuristic, shown as a **"Review From"** date. The 12-month age is **not** the statutory eligibility condition; relief becomes available when the debt is written off in the accounts under s. 53(3).
+:::
 
 The legal policy is corrective: if output VAT was paid on a supply that is not ultimately collected, the law may permit relief to avoid permanent overpayment.
 

--- a/docs/statutes/filing-payment-deadlines.md
+++ b/docs/statutes/filing-payment-deadlines.md
@@ -12,7 +12,7 @@ Statutory Basis: [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (
 
 [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 47(1)(a) sets the **standard filing rule** — returns and payment due within **21 days** of the end of the tax period. Large taxpayers fall under [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 46, which compresses the window to **14 days** for the specified large-taxpayer threshold.
 
-Returns and associated payments must be made by the required due date, with late filing or late payment triggering penalties (see [Assessments, Interest, and Penalties](/docs/statutes/assessments-interest-penalties)) and late-payment interest under [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 60 (Prime + 1% on the unpaid balance).
+Returns and associated payments must be made by the required due date, with late filing or late payment triggering fines and interest under [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 47A — including interest on outstanding tax at the Central Bank of The Bahamas prime lending rate plus 1% (s. 47A(4)). See [Assessments, Interest, and Penalties](/docs/statutes/assessments-interest-penalties).
 
 Deadline compliance is a core statutory obligation: even accurate calculations can produce exposure when submission or payment occurs after the due date.
 

--- a/docs/statutes/time-of-supply-period-assignment.md
+++ b/docs/statutes/time-of-supply-period-assignment.md
@@ -14,9 +14,10 @@ Statutory Basis: [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (
 
 Section 32 includes sub-rules for specific supply types:
 
-- **§32(2) — Continuous Supply** — supplies that do not have a single discrete tax point (e.g., utility services, subscriptions)
-- **§32(3) — Advance Payment** — supplies for which payment precedes delivery (deposits, retainer fees)
-- **§32 read with §52** — retention payments (held back amounts released after acceptance)
+- **§32(8) — Continuous Supply** — supplies that do not have a single discrete tax point (e.g., utility services, subscriptions); the tax point falls at the end of each billing period, or earlier if payment is received
+- **§32(11) — Advance Payment** — supplies for which payment precedes delivery (deposits, retainer fees); the tax point is the date payment is received
+- **§32(15) — Goods on Approval** — goods supplied on a trial/approval basis; the tax point is when the goods are adopted, or 12 months after delivery, whichever is earlier
+- **§32(17) — Retention Payment** — held-back amounts on a contract; the tax point is the earlier of when the retained consideration falls due or is received
 
 Transaction dating is reinforced by [Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), s. 15 (transaction dating requirements) and the amended s. 15A (effective April 1, 2025).
 

--- a/docs/transactions/manual-entry.mdx
+++ b/docs/transactions/manual-entry.mdx
@@ -68,12 +68,12 @@ When VAT rates change, the system displays rate transition guidance for transact
 
 For most transactions you can leave this collapsed — the default `Simple Supply` covers normal sale and purchase timing. Expand the **§32 Section Supply Type** panel only when the tax-point timing differs from the invoice/delivery date, for example:
 
-- Advance payments and deposits taken before delivery (`s. 32(3)`)
-- Continuous supplies invoiced periodically (`s. 32(4)`)
-- Construction-style retention payments released later (`s. 32(5)`)
-- Goods supplied on approval (`s. 32(6)`)
+- Advance payments and deposits taken before delivery (`s. 32(11)`)
+- Continuous supplies billed at the end of each billing period (`s. 32(8)`)
+- Construction-style retention payments released later (`s. 32(17)`)
+- Goods supplied on approval (`s. 32(15)`)
 
-The selected sub-clause is persisted on the transaction and forms part of the `VATCalculationProof` audit record. See [Section 32 Tax-Point Scenarios](/docs/transactions/section-32-tax-points) for a full guide.
+The selected supply type is persisted on the transaction and forms part of the `VATCalculationProof` audit record. See [Section 32 Tax-Point Scenarios](/docs/transactions/section-32-tax-points) for a full guide.
 
 ## Fraud Detection
 

--- a/docs/transactions/section-32-tax-points.md
+++ b/docs/transactions/section-32-tax-points.md
@@ -6,63 +6,63 @@ description: Five sub-clauses of VAT Act Section 32 that govern when VAT becomes
 
 # Section 32 Tax-Point Scenarios
 
-The **tax point** of a transaction is the moment VAT becomes due — not necessarily the moment the goods or services were delivered. For most transactions the two coincide; for advance payments, continuous supplies, retentions, and goods supplied on approval, [Section 32 of the Value Added Tax Act, 2014 (as amended by the VAT (Amendment) (No. 2) Act, 2021)](https://laws.bahamas.gov.bs/), specifically [s. 32(3)–(6)](https://laws.bahamas.gov.bs/), defines a different timing rule.
+The **tax point** of a transaction is the moment VAT becomes due — not necessarily the moment the goods or services were delivered. For most transactions the two coincide; for advance payments, continuous supplies, retentions, and goods supplied on approval, [Section 32 of the Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/) defines a different timing rule under sub-sections **(8)**, **(11)**, **(15)**, and **(17)**.
 
 When you enter a transaction in CoralLedger Comply you can expand the **§32 Section Supply Type** panel and select the sub-clause that governs the tax point. The selection is captured on the transaction record and forms part of the [audit-trail reproducibility evidence](/docs/audit/) for the seven-year retention period.
 
 Most entries do not need a non-default selection. The selector exists for the regulated minority where it does.
 
-## The five sub-clauses
+## The five supply types
 
-| Sub-clause | Comply enum value | Tax-point trigger |
+| Comply enum value | Sub-section | Tax-point trigger |
 |---|---|---|
-| Default (`s. 32(1)`) | `SimpleSupply` | The standard supply timing — VAT due when the supply is made (the delivery/invoice date in most cases). |
-| `s. 32(3)` | `AdvancePayment` | VAT due **when the advance payment is received** — even if delivery happens later. |
-| `s. 32(4)` | `ContinuousSupply` | VAT due **on each invoice issued** for a continuous service (utilities, leases, retainers). |
-| `s. 32(5)` | `RetentionPayment` | VAT on the retained portion of a payment becomes due **when the retention is released**, not when the original invoice was issued. |
-| `s. 32(6)` | `GoodsOnApproval` | VAT due **when the customer confirms acceptance**, not when goods were dispatched. |
+| `SimpleSupply` | Default (no Section 32 adjustment) | The standard supply timing — VAT due when the supply is made (the delivery/invoice date in most cases). |
+| `ContinuousSupply` | `s. 32(8)` | VAT due **at the end of each billing period** (or earlier, if a payment is received before the period ends) for a continuous service such as utilities, leases, or retainers. |
+| `AdvancePayment` | `s. 32(11)` | VAT due **when the advance payment is received** — even if delivery happens later. |
+| `GoodsOnApproval` | `s. 32(15)` | VAT due **when the customer adopts the goods, or 12 months after delivery, whichever is earlier** — not when goods were dispatched. |
+| `RetentionPayment` | `s. 32(17)` | VAT on the held-back consideration becomes due on the **earlier of when it falls due or is received**, not when the original invoice was issued. |
 
 ## When to pick a non-default value
 
-### `s. 32(3)` — Advance Payment
+### `s. 32(11)` — Advance Payment
 
 You took a deposit before performing the work. The deposit is a taxable consideration in its own right — VAT on the deposit is due in the period the deposit was received, even if the final invoice and delivery happen later.
 
 > **Example.** You issue an estimate for a B$10,000 project. The customer pays a 50% advance deposit of B$5,000 in March 2026. The remaining B$5,000 is invoiced and paid in April 2026 when work completes.
 >
-> The March deposit is a `s. 32(3)` advance payment — output VAT on B$5,000 belongs in the March VAT return. The April invoice represents the remaining B$5,000 of the supply and belongs in the April return.
+> The March deposit is a `s. 32(11)` advance payment — output VAT on B$5,000 belongs in the March VAT return. The April invoice represents the remaining B$5,000 of the supply and belongs in the April return.
 
-Misclassifying the advance as a normal sale (defaulting to `SimpleSupply`) would defer the entire B$10,000 of output VAT to April, which is incorrect under s. 32(3).
+Misclassifying the advance as a normal sale (defaulting to `SimpleSupply`) would defer the entire B$10,000 of output VAT to April, which is incorrect under s. 32(11).
 
-### `s. 32(4)` — Continuous Supply
+### `s. 32(8)` — Continuous Supply
 
 A continuous supply is a service or supply that does not have a discrete delivery point — utilities (electricity, water), leases, monthly retainers, subscriptions, ongoing professional services on a fixed monthly fee.
 
-> **Example.** You provide a monthly compliance-advisory retainer at B$2,000/month. Each month you issue a separate invoice for that month's service.
+> **Example.** You provide a monthly compliance-advisory retainer at B$2,000/month, billed at the end of each month.
 >
-> Each invoice is a `s. 32(4)` continuous-supply tax point — output VAT is due on each invoice in the period it was issued. You do not aggregate the year and treat it as one taxable event.
+> Each billing period is a `s. 32(8)` continuous-supply tax point — output VAT is due at the end of the period (or earlier, if the customer pays before the period ends). You do not aggregate the year and treat it as one taxable event.
 
-If your continuous supply has a single contract term (e.g. an annual subscription invoiced once up-front), it is **not** a `s. 32(4)` continuous supply — it is either a `s. 32(1)` simple supply (if billed in full at the start) or a `s. 32(3)` advance payment (if the payment precedes the supply).
+If your continuous supply has a single contract term (e.g. an annual subscription invoiced once up-front), it is **not** a `s. 32(8)` continuous supply — it is either a `SimpleSupply` (if billed in full at the start) or a `s. 32(11)` advance payment (if the payment precedes the supply).
 
-### `s. 32(5)` — Retention Payment
+### `s. 32(17)` — Retention Payment
 
-In construction and similar contracts the customer commonly withholds 5–10% of each progress payment until practical completion or a defect-liability period expires. That retained portion does not trigger VAT until it is actually released.
+In construction and similar contracts the customer commonly withholds 5–10% of each progress payment until practical completion or a defect-liability period expires. That retained portion does not trigger VAT until the held-back consideration falls due or is received.
 
 > **Example.** You complete B$50,000 of certified work on a construction contract. The customer pays you B$45,000 and retains B$5,000 against defects, releasable on practical completion in six months.
 >
-> Output VAT on the B$45,000 is due now under `s. 32(1)`. Output VAT on the B$5,000 retention is **not yet due** — record it as a `s. 32(5)` retention payment. When the retention is released, you record the release transaction and Comply triggers the VAT on the B$5,000 in that period's return.
+> Output VAT on the B$45,000 is due now. Output VAT on the B$5,000 retention is **not yet due** — record it as a `s. 32(17)` retention payment. When the retention falls due or is released, you record the release transaction and Comply triggers the VAT on the B$5,000 in that period's return.
 
 If you treat the retention as immediately taxable (`SimpleSupply`), you have over-declared output VAT and will have to claim it back as a correction. If you forget to record the release when it happens, you will under-declare in the release period.
 
-### `s. 32(6)` — Goods on Approval
+### `s. 32(15)` — Goods on Approval
 
-You ship goods to a customer for a trial / approval period — they have the right to return them. The supply does not legally take place until the customer either confirms acceptance or the return window expires.
+You ship goods to a customer for a trial / approval period — they have the right to return them. The supply does not legally take place until the customer adopts the goods, or 12 months pass from delivery, whichever is earlier.
 
 > **Example.** You ship B$3,000 of demonstration equipment to a customer with a 30-day approval window. On day 25 the customer confirms they will keep the equipment and the invoice is issued.
 >
-> The taxable supply happened on day 25, not on the dispatch date — record the transaction as `s. 32(6)` Goods on Approval. Output VAT belongs in the period containing day 25.
+> The taxable supply happened on day 25 (adoption), not on the dispatch date — record the transaction as `s. 32(15)` Goods on Approval. Output VAT belongs in the period containing day 25. Had the customer neither adopted nor returned the goods, the tax point would fall 12 months after delivery.
 
-If you had dispatched on the last day of one month and the customer confirmed on the first day of the next month, the difference between `SimpleSupply` and `s. 32(6)` is which VAT return the entry belongs in — a one-period misclassification on the boundary.
+If you had dispatched on the last day of one month and the customer confirmed on the first day of the next month, the difference between `SimpleSupply` and `s. 32(15)` is which VAT return the entry belongs in — a one-period misclassification on the boundary.
 
 ## How Comply uses the selection
 
@@ -74,9 +74,9 @@ The selected sub-clause is:
 
 There is no automated re-classification — once you have entered a transaction with a sub-clause, Comply trusts that selection. Picking the wrong sub-clause is a defensible practitioner decision documented in the audit trail; failing to record a non-default sub-clause when one applies is a regulated misstatement risk.
 
-## What about §32(2)?
+## Other Section 32 sub-sections
 
-[Section 32(2)](https://laws.bahamas.gov.bs/) governs the timing of input-tax recovery — it is about *purchases*, not *sales*. Comply applies §32(2) automatically when you record purchase-side transactions; there is no user-facing selector for it. The five user-facing supply types above are §32(1) (default) and §32(3)–(6).
+Section 32 contains further sub-sections beyond the supply types above. Comply exposes a user-facing selector only for the sales-side tax-point scenarios that a practitioner needs to choose between — the default simple supply plus the continuous-supply, advance-payment, goods-on-approval, and retention scenarios listed above. Other Section 32 sub-sections are applied by the calculation engine where they are relevant and do not require a selection.
 
 ## Next steps
 

--- a/docs/vat-returns/filing-wizard.md
+++ b/docs/vat-returns/filing-wizard.md
@@ -26,23 +26,25 @@ After step 5 you are presented with a **Filing Artifacts Ready** success card �
 
 ## Step 4: Approval — Section 61 acknowledgement {#step-4-approval-section-61-acknowledgement}
 
-When you click **Approve** at step 4, Comply opens the Approve Filing dialog. The first panel is the Section 61 Penalty Acknowledgement.
+When you click **Approve** at step 4, Comply opens the Approve Filing dialog. The first panel is the Penalty Acknowledgement.
 
-The dialog quotes the relevant rule from the [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/), s. 61, and tells you the **maximum penalty exposure for this specific return**:
+The dialog records your review of the penalty exposure that applies under the [Value Added Tax Act, 2014](https://laws.bahamas.gov.bs/) and your acceptance of responsibility for the accuracy of this return:
 
-> Under Bahamas VAT Act 2014, Section 61, the maximum penalty for an incorrect return is **up to 200% of the understated or over-claimed VAT** — **up to B$X on this return**.
+> Under the Value Added Tax Act, 2014, penalties for understatement or evasion apply. This acknowledgement records your review of that exposure and your acceptance of responsibility for the accuracy of this return.
 
-The dollar figure is calculated as `|Net VAT due| × 2`. The absolute value is used so credit and zero-balance returns also display a meaningful exposure (the figure represents what the penalty *could* be if the return were later found to be materially incorrect).
+You tick the acknowledgement checkbox — *"I have reviewed the penalty exposure under the VAT Act and accept responsibility for the accuracy of this return"* — to proceed. When you do, Comply writes an audit-ledger entry (event identifier `ACK_SECTION61`) **before** it transitions the return state. The entry is recorded with neutral wording — *"User acknowledged regulatory exposure under the VAT Act before filing return for [period]"*. This ordering matters — see [Audit-before-lock](#audit-before-lock).
 
-You must tick the acknowledgement checkbox to proceed. When you do, Comply writes an `ACK_SECTION61` audit-ledger entry **before** it transitions the return state. This ordering matters — see [Audit-before-lock](#audit-before-lock).
+:::note
+The dialog does **not** quote a specific penalty percentage or compute a dollar figure. Section 61 of the VAT Act is *"Assessment as evidence in proceedings"* — an evidentiary provision, **not** a penalty section — so no "% of unpaid VAT" multiplier is shown. The audit event retains the identifier `ACK_SECTION61` for continuity with the existing audit schema. The statutory fines for late filing and late payment are set out in s. 47A — see [Assessments, Interest, and Penalties](/docs/statutes/assessments-interest-penalties).
+:::
 
 ## Step 4: Approval — Signatory capture {#step-4-approval-signatory-capture}
 
-Below the §61 panel is the Authorised Signatory panel. Comply captures three things:
+Below the acknowledgement panel is the Authorised Signatory panel. Comply captures three things:
 
 - **Full Name** — the natural-person name of the individual signing for this return, up to 200 characters.
 - **Capacity** — a drop-down listing the four [Signatory Capacities](#signatory-capacities) recognised by Bahamian VAT practice.
-- **"I confirm I am authorised…" checkbox** — a separate declaration distinct from the §61 acknowledgement.
+- **"I confirm I am authorised…" checkbox** — a separate declaration distinct from the penalty acknowledgement.
 
 When you click **Approve** to close the dialog, Comply writes a `RETURN_APPROVED_BY_SIGNATORY` audit-ledger entry capturing the name and capacity, then transitions the return state to **Ready to File**.
 
@@ -113,7 +115,7 @@ While the return sits in **Awaiting Lodgement**, no further audit-ledger writes 
 
 The five-step structure encodes three regulatory facts:
 
-1. **The §61 penalty is not a hidden term in a generic ToS** — Comply quotes the rule, calculates the specific dollar exposure, and asks for an explicit acknowledgement.
+1. **The penalty acknowledgement is not a hidden term in a generic ToS** — Comply surfaces the penalty exposure that applies under the VAT Act and asks for an explicit acknowledgement, recorded under the `ACK_SECTION61` audit event.
 2. **The signatory declaration is captured per-return**, with the name and capacity persisted to the audit ledger. There is no "signed once, applies forever" shortcut.
 3. **Comply does not file on your behalf with the DIR.** The artifacts-ready / submitted distinction is enforced in the UI wording so a reader cannot confuse the two.
 


### PR DESCRIPTION
## Why

The docs site was last updated **2026-06-07**; Comply has advanced to **2026-06-26**, including a major **regulatory-citation canonicalization** (Cass + Julian verbatim reads, June 8–24) and a **dashboard factual-status / honesty-gate** reframe. Several § citations and penalty figures in the docs now contradict the code's source-of-truth. Per the standing rule that *code is canonical for rates / classifications / section numbers / dates*, this brings the docs back into line.

Every value here is taken from the Comply source-of-truth (`Section32ResolverService.cs`, `PenaltyRiskService.cs`, `StatusBasedComplianceService.cs`, `AttestationVariant.cs`, `appsettings.json`).

## Changes

**Fabricated penalty figures stripped**
- Removed "§61 — up to 200% of unpaid VAT" everywhere (filing wizard, attestation declarations, compliance pages, statutes). §61 is *"Assessment as evidence in proceedings"* — **not** a penalty section.
- Removed the "5% monthly" interest figure.

**§47A late-filing / payment / interest**
- Anchored on s. 47A: late filing = greater of $100 or 2% of tax payable; late payment = 10%; interest = prime + 1% (was s.60/s.61).

**§32 time of supply**
- Corrected sub-sections to **(8)** continuous, **(11)** advance, **(15)** goods-on-approval, **(17)** retention (were (2)/(3)/(4)/(5)/(6)/§52); added the goods-on-approval 12-month ceiling.

**Attestation variants A/B/C**
- Re-described as **practice-area declarations** (General Compliance / Return Preparation / Advisory) matching `AttestationVariant` in code — they were incorrectly mapped to §32 time-of-supply sub-sections.

**Bad-debt relief**
- Re-anchored on **s. 53(3) write-off date**; the 12-month age is demoted to a "Review From" surfacing prompt (was s.20 + a 12-month eligibility trigger). s.20 is Voluntary Registration.

**§50 construction**
- Documented the now-active major-construction input-VAT restriction (s. 50(1A) prohibition / s. 50(1B) carve-out, strictly > $1M).

**Dashboard honesty framing**
- Added the factual-status caveat, filing-timeliness cap explanation, pending-review exclusion, and level+direction risk-indicator framing.

**Reference / canon pages**
- Updated `statutory-citations.md`, `amendment-chain-verification-memo.md`, `glossary.md`, `index.md` to match.

## Citation-tier discipline
Where an anchor is HELD / not verbatim-sourced (e.g. §47A(4A) real-property carve-out, §50 limb sub-numbers, the amending-Act number for §50), behavior is described neutrally and no guessed sub-section is shipped.

## Verification
- `npm run build` — succeeds, MDX compiles, no broken-link failures.
- REQ-MSG-001 banned-phrase scan — no new violations introduced.
- Canon grep for `200%` / `§61`-as-penalty / `s.20` / wrong `§32(n)` — all remaining hits are corrective text or the legitimate `ACK_SECTION61` audit-event name.

## Follow-ups (code-side residuals to file separately, not in this docs PR)
- `IntelligenceDashboard.razor` label "Late Filing Penalties (Section 61)" and `VATEntry.razor` "Advance Payment (s.32(3))" still carry stale anchors.
- `BCKBService.cs` retains a "200% penalty risk" string that contradicts its own "no 200% figure ships" summary.

A separate weekend **video-recording guide** was produced for the doc demo videos (in the Comply repo task folder); embedding via `<DemoVideo>` will follow once clips are recorded.