### PR TITLE
Align docs with the public estate

### DIFF
--- a/docs/compliance/index.md
+++ b/docs/compliance/index.md
@@ -20,7 +20,7 @@ Non-compliance with Bahamian VAT regulations can result in:
 ## Compliance Features
 
 ### Real-Time Scoring
-Your compliance score (A+ to F) is calculated from:
+Your compliance score (A to F) is calculated from:
 - Filing Compliance (30%)
 - Data Quality (25%)
 - Rate Accuracy (25%)

--- a/docs/compliance/vat-2025-reforms.md
+++ b/docs/compliance/vat-2025-reforms.md
@@ -162,7 +162,7 @@ CoralLedger Comply includes dedicated dashboards for each 2025 reform:
 
 ## Need Help?
 
-The 2025 reforms are complex. Contact us for assistance:
+The VAT framework, as amended through 2026, is complex. Contact us for assistance:
 - **Email**: support@digitalcarib.com
 - **Phone**: Schedule a consultation
 

--- a/docs/firm-portal/batch-filing.md
+++ b/docs/firm-portal/batch-filing.md
@@ -30,7 +30,7 @@ For high-stakes returns (restricted-segment, large net VAT exposure, recent comp
 
 ## Accessing Batch Filing
 
-Navigate to **Firm Portal → Batch VAT Filing** (the quick action on the landing page) or directly to `/firm/batch-filing`.
+Navigate to **Firm Portal → Batch return preparation** (the quick action on the landing page) or directly to `/firm/batch-filing`.
 
 ## The four-step wizard
 

--- a/docs/firm-portal/index.mdx
+++ b/docs/firm-portal/index.mdx
@@ -41,7 +41,7 @@ The Quick Actions row sits below the KPI cards and offers four navigation shortc
 | Button | Destination |
 |---|---|
 | **Add Client** | `/firm/clients/onboard` — see [Adding a client](#adding-a-client) below |
-| **Batch VAT Filing** | `/firm/batch-filing` — see [Batch Filing](/docs/firm-portal/batch-filing) |
+| **Batch return preparation** | `/firm/batch-filing` — see [Batch Filing](/docs/firm-portal/batch-filing) |
 | **Multi-Client Reports** | `/firm/reports` — see [Firm Analytics](/docs/firm-portal/analytics) |
 | **Staff Productivity** | `/firm/productivity` — workload distribution + per-staff metrics |
 | **Refresh** | Reloads dashboard data without leaving the page |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -18,7 +18,7 @@ CoralLedger Comply is currently in free beta. All features are available at no c
 
 ## What is CoralLedger Comply?
 
-CoralLedger Comply is a VAT compliance platform built specifically for businesses operating under The Bahamas VAT framework and the 2025 reforms. It helps you:
+CoralLedger Comply is a VAT compliance platform built specifically for businesses operating under The Bahamas VAT framework, as amended through 2026. It helps you:
 
 - **Record transactions** via CSV import or manual entry
 - **Review and assign VAT categories** (Standard, Reduced, Zero-Rated, Exempt) with guided suggestions

--- a/docs/getting-started/self-filing.md
+++ b/docs/getting-started/self-filing.md
@@ -42,7 +42,7 @@ The dashboard looks slightly different depending on your filing mode.
 
 | Widget | Description |
 |--------|-------------|
-| **Compliance Score** | Your real-time A+ to F compliance grade |
+| **Compliance Score** | Your real-time A to F compliance grade |
 | **Next Filing Deadline** | Countdown to your next return due date |
 | **Net VAT Position** | Current period's VAT payable or refundable |
 | **Recent Activity** | Your latest transactions and actions |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -36,7 +36,7 @@ The reverse charge mechanism for construction services exceeding $1 million. Par
 The Comptroller of the Department of Inland Revenue, responsible for VAT administration in The Bahamas.
 
 ### Compliance Score
-A grade (A+ to F) indicating your VAT compliance health based on categorization accuracy, filing timeliness, documentation, and anomaly resolution.
+A grade (A to F) indicating your VAT compliance health based on categorization accuracy, filing timeliness, documentation, and anomaly resolution.
 
 ## D
 

--- a/docs/reference/vat-rates.mdx
+++ b/docs/reference/vat-rates.mdx
@@ -130,7 +130,7 @@ Because exempt supplies block input tax credit recovery, a business selling both
 | VAT (Amendment) Act, 2025 | NEUTRAL (citation stripped) | September 2025 milestone date retained on page pending source recovery | Gazetted instrument not locatable in this repository snapshot | No |
 | VAT (Amendment) Act 2026 (No. 4), s. 3, Second Schedule Part I item (19) | PRIMARY | April 2026 food→Exempt treatment | Cass 2026-06-06 decision record (companion PR #214 context) | Yes |
 :::info Transition Dates
-The 2025 reforms did **not** commence on a single date. CoralLedger Comply applies the correct rate based on the transaction date you enter, using the staged April 1, 2025, July 1, 2025, September 1, 2025, and April 1, 2026 commencement points. Transactions near rate transition dates display applicable rate guidance to help you confirm the correct category.
+The VAT framework, as amended through 2026, did **not** commence on a single date. CoralLedger Comply applies the correct rate based on the transaction date you enter, using the staged April 1, 2025, July 1, 2025, September 1, 2025, and April 1, 2026 commencement points. Transactions near rate transition dates display applicable rate guidance to help you confirm the correct category.
 :::
 
 ## Next Steps

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -30,6 +30,7 @@ const algoliaAppId = process.env.ALGOLIA_APP_ID;
 const algoliaApiKey = process.env.ALGOLIA_API_KEY;
 const algoliaIndexName = process.env.ALGOLIA_INDEX_NAME;
 const hasAlgoliaConfig = Boolean(algoliaAppId && algoliaApiKey && algoliaIndexName);
+const supportEmail = process.env.SUPPORT_EMAIL?.trim();
 
 const config: Config = {
   title: 'CoralLedger Comply Documentation',
@@ -170,14 +171,19 @@ const config: Config = {
               label: 'System Status',
               href: 'https://status.coralledger.com/status',
             },
+            ...(supportEmail ? [{ label: 'Contact Us', href: `mailto:${supportEmail}` }] : []),
             {
-              label: 'Contact Us',
-              href: 'mailto:privacy@digitalcarib.com',
+              label: 'Terms of Service',
+              href: `${complyUrl}/legal/terms-of-service`,
+            },
+            {
+              label: 'Privacy Policy',
+              href: `${complyUrl}/legal/privacy-policy`,
             },
           ],
         },
       ],
-      copyright: `© ${new Date().getFullYear()} Carib Digital Labs. All rights reserved.`,
+      copyright: `CoralLedger Comply · a Carib Digital Labs product<br />© ${new Date().getFullYear()} Carib Digital Labs. All rights reserved.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -5,25 +5,34 @@ import styles from './styles.module.css';
 
 type FeatureItem = {
   title: string;
-  icon: string;
+  icon: 'landmark' | 'shield' | 'clipboard' | 'check' | 'building' | 'transfer';
   description: ReactNode;
+};
+
+const iconPaths: Record<FeatureItem['icon'], ReactNode> = {
+  landmark: <><path d="M3 10h18"/><path d="M5 10V20M9 10V20M15 10V20M19 10V20M2 20h20M12 3 3 8h18z"/></>,
+  shield: <path d="M12 3 4 6v5c0 5 3.4 8.7 8 10 4.6-1.3 8-5 8-10V6z"/>,
+  clipboard: <><rect x="5" y="4" width="14" height="17" rx="2"/><path d="M9 4a3 3 0 0 1 6 0v2H9zM9 11h6M9 15h6"/></>,
+  check: <><circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/></>,
+  building: <><path d="M4 21V5h10v16M14 9h6v12M8 9h2M8 13h2M8 17h2M17 13h1M17 17h1"/></>,
+  transfer: <><path d="M7 7h13l-3-3M17 17H4l3 3"/><path d="m20 7-3 3M4 17l3-3"/></>,
 };
 
 const FeatureList: FeatureItem[] = [
   {
     title: 'Built for The Bahamas',
-    icon: '🇧🇸',
+    icon: 'landmark',
     description: (
       <>
         Designed specifically for VAT compliance under The Bahamas VAT Act 2014
-        and 2025 reforms. Supports standard (10%), reduced (5%), zero-rated, and
+        as amended through 2026. Supports standard (10%), reduced (5%), zero-rated, and
         exempt supplies with dedicated compliance dashboards.
       </>
     ),
   },
   {
     title: 'Audit Defense',
-    icon: '🛡️',
+    icon: 'shield',
     description: (
       <>
         Immutable hash-chain verified audit trail with 7-year retention.
@@ -34,7 +43,7 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Validated Returns',
-    icon: '📋',
+    icon: 'clipboard',
     description: (
       <>
         Generate VAT returns with 10-point pre-flight validation. Preview totals,
@@ -45,27 +54,27 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: 'Compliance Scoring',
-    icon: '✅',
+    icon: 'check',
     description: (
       <>
-        Real-time compliance score from A+ to F based on data quality, timeliness,
+        Real-time compliance score from A to F based on data quality, timeliness,
         accuracy, and completeness. Anomaly detection alerts you to potential issues.
       </>
     ),
   },
   {
     title: 'Firm Portal',
-    icon: '🏢',
+    icon: 'building',
     description: (
       <>
-        Perfect for accounting firms. Batch filing for multiple clients, firm-wide
+        Perfect for accounting firms. Batch return preparation for multiple clients, firm-wide
         analytics, staff productivity tracking, and centralized deadline management.
       </>
     ),
   },
   {
     title: 'Import & Export',
-    icon: '📤',
+    icon: 'transfer',
     description: (
       <>
         Import transactions via CSV or Excel from any accounting system. Column
@@ -81,7 +90,9 @@ function Feature({title, icon, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
       <div className="text--center padding-horiz--md">
-        <div className={styles.featureIcon}>{icon}</div>
+        <svg className={styles.featureIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          {iconPaths[icon]}
+        </svg>
         <Heading as="h3">{title}</Heading>
         <p>{description}</p>
       </div>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -6,8 +6,11 @@
 }
 
 .featureIcon {
-  font-size: 3rem;
+  width: 3rem;
+  height: 3rem;
+  margin-inline: auto;
   margin-bottom: 1rem;
+  color: var(--ifm-color-primary);
 }
 
 .features h3 {


### PR DESCRIPTION
## What changed
- replaces the stale `2025 reforms` framing with the frozen `as amended through 2026` wording
- aligns batch-return preparation and A-to-F scorer vocabulary with the shipped product
- replaces homepage emoji features with consistent SVG line icons
- adds canonical Comply Terms and Privacy links to the docs footer
- aligns the estate identity line and gates general support on the `SUPPORT_EMAIL` config token

## Why
Docs was repeating stale public-estate claims and using privacy contact as general support. The shipped four-domain scorer tops out at A, not A+.

## Reviewer notes
- `SUPPORT_EMAIL` intentionally remains unset until Robbie confirms both the mailbox domain and live routing.
- statutory uses of `Comptroller` were preserved; this PR does not silently rewrite statutory prose.
- in-app browser was unavailable, so no pixel-pass claim is made.

## Validation
- `npm run typecheck`
- `npm run build` (broken-link gate passed)
- negative scans for `2025 reforms` and `A+ to F`
- `git diff --check`