### PR TITLE
Strip the Form 301 export and DIR-accepted claims (#4202)

### DIFF
--- a/docs/data-ops/data-export.md
+++ b/docs/data-ops/data-export.md
@@ -23,7 +23,7 @@ Navigate to **Admin > Data Export** (route: `/admin/data-export`). This surface 
 | **Transactions** | CSV, JSON |
 | **VAT Returns** | Excel |
 | **Compliance Report** | (formatted output) |
-| **VAT XML** | DIR-accepted XML for OTAS submission |
+| **VAT XML** | Structured XML of the return figures |
 | **Anomaly Report** | (formatted output) |
 
 Each export is generated synchronously — when you click **Export**, the file is generated and offered for download immediately. There is no separate queue or job-status surface.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -41,7 +41,7 @@ CoralLedger Comply is a VAT compliance platform built specifically for businesse
 - **VAT Returns** — Draft, submit, and amend returns with full lifecycle tracking
 - **Compliance Intelligence** — Real-time scoring, anomaly detection, and risk assessment
 - **Firm Portal** — Multi-client dashboard with batch filing for accounting firms
-- **Export Suite** — PDF, XML, Excel, CSV, and Form 301 exports
+- **Export Suite** — PDF, XML, Excel, and CSV exports
 - **Audit Trail** — Immutable hash-chain verified activity log
 - **Security** — 2FA, IP blocking, fraud alerts, and role-based access control
 

--- a/docs/getting-started/self-filing.md
+++ b/docs/getting-started/self-filing.md
@@ -96,11 +96,11 @@ Export your completed return for submission to the DIR's Online Tax Administrati
 
 1. Open the generated return
 2. Click **Export**
-3. Choose your preferred format — **PDF**, **XML**, **Excel**, or **Form 301**
+3. Choose your preferred format — **PDF**, **XML**, or **Excel**
 4. Submit the figures through the [DIR OTAS portal](https://otas.revenue.gov.bs) or in person at a DIR office
 
 :::info OTAS Export
-The XML export is formatted for OTAS upload — you submit it to the DIR through the OTAS portal yourself. Use PDF for your own records and in-person filings.
+The XML export is a structured file of your return figures. You submit your return to the DIR yourself, through the OTAS portal or in person. Use PDF for your own records and in-person filings.
 :::
 
 ## When to Use Self-Filing Mode

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -17,7 +17,7 @@ A chronological record of all changes made to transactions, categories, and VAT 
 The persistent record that a BICA-licensed practitioner has accepted the §32 attestation body text for a specific client. Has its own state machine (Active → Superseded / VoidedByAssignmentChange) and is distinct from the per-return Signatory Capacity Declaration captured at filing time. Required for §3 restricted-segment clients. See [§32 Attestation Overview](/docs/attestation/).
 
 ### Awaiting Lodgement
-The displayed label for the `AwaitingDirConfirmation` state — the return's artefacts (PDF / XML / Excel / Form 301) are generated and you now record the DIR lodgement externally. See the [VAT Returns lifecycle](/docs/vat-returns/).
+The displayed label for the `AwaitingDirConfirmation` state — the return's artefacts (PDF / XML / Excel) are generated and you now record the DIR lodgement externally. See the [VAT Returns lifecycle](/docs/vat-returns/).
 
 ## B
 

--- a/docs/vat-returns/filing-wizard.md
+++ b/docs/vat-returns/filing-wizard.md
@@ -24,7 +24,7 @@ Comply renders the wizard as a numbered timeline:
 | **2** | VAT Validation | The [10-point validation](/docs/vat-returns/return-preview) runs; you address blocking issues. | _(no audit write)_ |
 | **3** | Document Generation | Pre-flight check that the artifacts can be generated cleanly. | _(no audit write)_ |
 | **4** | **Approval** | You complete the [Section 61 acknowledgement](#step-4-approval-section-61-acknowledgement) and the [signatory capture](#step-4-approval-signatory-capture). The return transitions **Draft → Ready to File**. | `ACK_SECTION61`, then `RETURN_APPROVED_BY_SIGNATORY` |
-| **5** | **Submission** | Comply generates the PDF, XML, Excel, and Form 301 artifacts atomically and transitions **Ready to File → Filing in Progress → Awaiting Lodgement**. | `FILING_INITIATED`, `FILING_ARTIFACTS_GENERATED` |
+| **5** | **Submission** | Comply generates the PDF, XML and Excel artifacts atomically and transitions **Ready to File → Filing in Progress → Awaiting Lodgement**. | `FILING_INITIATED`, `FILING_ARTIFACTS_GENERATED` |
 
 After step 5 you are presented with a **Filing Artifacts Ready** success card — described below in [What "Filing Artifacts Ready" means](#what-filing-artifacts-ready-means).
 
@@ -93,7 +93,7 @@ You will not normally notice this behaviour because audit writes are fast. It ma
 When you click the Submit Filing button at step 5, Comply runs the finalisation routine, which:
 
 1. **Locks** the return for concurrent modification using a database-level compare-and-swap. A second concurrent caller (e.g. a duplicate browser tab) sees an error and does not duplicate work.
-2. **Generates** the PDF, XML, Excel, and Form 301 artifacts inside a single retry-safe transaction. Either all four are produced or none are persisted.
+2. **Generates** the PDF, XML and Excel artifacts inside a single retry-safe transaction. Either all three are produced or none are persisted.
 3. **Writes** two audit-ledger entries: `FILING_INITIATED` (the start-of-finalisation marker) and `FILING_ARTIFACTS_GENERATED` (the end-of-finalisation marker, carrying the artifact set's identifiers).
 4. **Transitions** the return through Ready to File → Filing in Progress → **Awaiting Lodgement**.
 
@@ -110,7 +110,7 @@ After step 5 completes, Comply displays a card titled **Filing Artifacts Ready**
 The Filing Artifacts Ready card offers three actions:
 
 - **Download PDF** — a human-readable summary for your records and for in-person filings.
-- **Download XML** — the DIR-accepted submission format for upload via OTAS.
+- **Download XML** — structured XML of the return figures.
 - **Record DIR Acknowledgement** — the in-app capture you complete after the DIR confirms receipt of your submission. See [Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement) for the full flow.
 
 While the return sits in **Awaiting Lodgement**, no further audit-ledger writes happen — the next lifecycle event is when you record the lodgement.

--- a/docs/vat-returns/generate-return.mdx
+++ b/docs/vat-returns/generate-return.mdx
@@ -51,9 +51,8 @@ Address any compliance alerts before finalizing your return. Critical alerts wil
 ### Step 5: Export
 Download your return in multiple formats:
 - **PDF** — Human-readable summary for your records, in-person filings, and client presentations
-- **XML** — DIR-accepted submission format for upload via OTAS
+- **XML** — structured XML of the return figures
 - **Excel** — Detailed analysis with calculated fields
-- **Form 301** — The structured DIR-specific submission artifact
 
 Transaction-level CSV exports (the underlying transactions, not the return itself) are available from the [Transactions](/docs/transactions/) listing page.
 

--- a/docs/vat-returns/index.md
+++ b/docs/vat-returns/index.md
@@ -49,7 +49,7 @@ Comply tracks every VAT return through a structured eight-state lifecycle. Each 
 |---|---|---|
 | **Draft** | Draft | Return created from the period's transactions; can still be edited |
 | **Ready to File** | Ready to File | All validations passed and the Section 61 acknowledgement + signatory have been captured. The return is locked from edits |
-| **Filing in Progress** | Filing in Progress | Artifacts (PDF / XML / Excel / Form 301) are being generated. Brief — usually seconds |
+| **Filing in Progress** | Filing in Progress | Artifacts (PDF / XML / Excel) are being generated. Brief — usually seconds |
 | **Awaiting Lodgement** | Awaiting Lodgement | Artifacts are ready. You now submit externally to the DIR via OTAS / a DIR office / an authorised agent, then return to Comply to record the lodgement |
 | **Lodged** | Lodged | You have recorded the DIR lodgement using **[Record DIR Acknowledgement](/docs/vat-returns/record-dir-acknowledgement)**. The `RETURN_LODGED_WITH_DIR` audit entry has been written. From here, you either retract (`Lodged` → `Awaiting Lodgement`, `RETURN_LODGEMENT_RETRACTED`) or record payment (`Lodged` → `Lodged & Paid`, `PAYMENT_RECORDED`) |
 | **Lodged & Paid** | Lodged & Paid | Final state for payable returns once cumulative payments cover the net VAT due. Credit/zero returns reach this state automatically immediately after Lodged |
@@ -80,9 +80,9 @@ Your return includes all standard Bahamas VAT return lines:
 - **Calculated Fields** - All L1-L31 fields computed from your transaction data
 - **Return Preview** - Review totals and validation before filing
 - **10-Point Validation** - Comprehensive pre-flight checks
-- **Export Formats** - PDF, XML, Excel, and Form 301 for DIR submission and your own records
+- **Export Formats** - PDF, XML and Excel for your own records and for submitting the figures yourself
 - **Amendment Support** - Correct lodged returns with change tracking
-- **Multi-Format Export** - Download a lodged return as PDF, XML, Excel, or Form 301
+- **Multi-Format Export** - Download a lodged return as PDF, XML or Excel
 
 ## Return Preview & Validation
 

--- a/docs/vat-returns/input-tax-apportionment.md
+++ b/docs/vat-returns/input-tax-apportionment.md
@@ -103,12 +103,11 @@ The full apportionment schedule is included in every return export:
 
 1. Open the VAT return for the relevant period
 2. Click **Export**
-3. Choose your preferred format: **PDF**, **Excel**, **XML**, or **Form 301**
+3. Choose your preferred format: **PDF**, **Excel**, or **XML**
 4. The export includes the apportionment schedule:
    - **PDF** — displayed as a clearly labelled section within the return document
    - **Excel** — included as a dedicated **Input Tax Apportionment** worksheet
    - **XML** — embedded under the apportionment element of the DIR-accepted submission payload
-   - **Form 301** — included in the structured DIR submission artifact
 
 The exported schedule contains:
 

--- a/docs/vat-returns/record-dir-acknowledgement.md
+++ b/docs/vat-returns/record-dir-acknowledgement.md
@@ -51,7 +51,7 @@ Comply runs the transition inside a single retry-safe transaction:
 2. Persists the lodgement date, method (and other-details if applicable), and reference number.
 3. Sets `FilingState = Lodged`.
 4. Best-effort syncs the corresponding **Filing Period** row so any late-filing banner clears.
-5. Writes the `RETURN_LODGED_WITH_DIR` audit-ledger entry. This entry carries an **artifact checksum dictionary** — SHA-checksums of the exact PDF / XML / Excel / Form 301 files you submitted — so the audit trail can later prove which specific artifacts were lodged.
+5. Writes the `RETURN_LODGED_WITH_DIR` audit-ledger entry. This entry carries an **artifact checksum dictionary** — SHA-checksums of the exact PDF / XML / Excel files you submitted — so the audit trail can later prove which specific artifacts were lodged.
 
 For credit and zero-balance returns, Comply then **auto-advances** the state to **Lodged & Paid** and writes a `NO_PAYMENT_DUE` audit-ledger entry. This second transition is part of the regulatory invariant — see [VR-STATE-001](#vr-state-001-every-return-passes-through-lodged-first) below.
 


### PR DESCRIPTION
Closes caribdigital/coralledgercomply#4202.

## The stronger reason, found while doing this

**Form 301 was never part of the atomic artifact set.** `Form301ExportService` is not injected into `FilingWorkflowService` at all — zero references. The workflow generates PDF and XML; Excel comes from its own service.

So this docs claim was **factually wrong about the product before the export was ever quarantined**:

> Comply generates the PDF, XML, Excel, and Form 301 artifacts atomically… Either **all four** are produced or none are persisted.

Corrected to three throughout — including `record-dir-acknowledgement.md`, which described SHA-checksums of a Form 301 file the product never produces.

## The quarantine reason

The export is **quarantined in production** as of `ea2231d7`, on Julian's ruling `JR-REGISTER-B-2026-08-08`: the feature dies as built regardless of whether Form 301 is a genuine DIR artifact, because the exporter was bound to none of the sealed canon (Form 32a v2.4). He ruled that the docs claim strips. RDF-1 §3 lists `Form 301` as a banned token.

## "DIR-accepted" also goes

It asserts what the Department does with our output — a claim about a third party's behaviour that nothing verifies. Replaced with what is true and checkable: *structured XML of the return figures*.

## Deliberately kept

**OTAS as the name of the DIR's portal**, and the guidance that the practitioner submits there or in person. That is factual about the DIR, not a claim about our output, and stripping it would remove correct guidance a self-filer needs.

The one exception: *"the XML export is formatted for OTAS upload"* **is** a conformance claim about our file, so it is reworded.

Flagging for **Julian**: RDF-1 §3 bans the `OTAS` token outright. I have read his B1 reasoning as being about *artifact identity* rather than the portal's name, and kept the portal references on that basis. If he intends the token ban literally, those go too — happy to follow up.

## Validation

Docusaurus production build passes, including the broken-link check.

## Files

9 files: `getting-started/index.md`, `getting-started/self-filing.md`, `reference/glossary.md`, `vat-returns/filing-wizard.md`, `vat-returns/index.md`, `vat-returns/generate-return.mdx`, `vat-returns/input-tax-apportionment.md`, `vat-returns/record-dir-acknowledgement.md`, `data-ops/data-export.md`